### PR TITLE
fix: 태그 추가에서 한글 입력시 마지막 글자 두 번 입력되는 버그 수정

### DIFF
--- a/src/components/Buttons/HeartButton.tsx
+++ b/src/components/Buttons/HeartButton.tsx
@@ -44,14 +44,18 @@ const HeartButton = ({ isLiked, postId }: HeartButtonProps) => {
         | Post[]
         | undefined;
       queryKeys.forEach((queryKey) => {
-        if (queryKey[0] === 'posts' && queryKey[1] !== 'votes') {
+        if (
+          queryKey[0] === 'posts' &&
+          queryKey[1] !== 'votes' &&
+          queryKey[1] !== 'vote'
+        ) {
           const prevPostData:
             | InfiniteData<PostWithPagenation, unknown>
             | PostWithPagenation
             | Post[]
             | undefined = queryClient.getQueryData(queryKey);
           prevData = prevPostData;
-          if (prevPostData && Object.keys(prevPostData).length > 7) {
+          if (prevPostData && Object.keys(queryKey[1]).length === 2) {
             const newPostData = (
               prevPostData as PostWithPagenation
             )?.content.map((post) => {
@@ -72,7 +76,7 @@ const HeartButton = ({ isLiked, postId }: HeartButtonProps) => {
             });
 
             queryClient.setQueryData(queryKey, newPostData);
-          } else {
+          } else if (prevPostData && Object.keys(queryKey[1]).length === 1) {
             const realUpdatedData = (
               prevPostData as InfiniteData<PostWithPagenation, unknown>
             )?.pages.map((page) => {
@@ -116,14 +120,18 @@ const HeartButton = ({ isLiked, postId }: HeartButtonProps) => {
         | Post[]
         | undefined;
       queryKeys.forEach((queryKey) => {
-        if (queryKey[0] === 'posts' && queryKey[1] !== 'votes') {
+        if (
+          queryKey[0] === 'posts' &&
+          queryKey[1] !== 'votes' &&
+          queryKey[1] !== 'vote'
+        ) {
           const prevPostData:
             | InfiniteData<PostWithPagenation, unknown>
             | PostWithPagenation
             | Post[]
             | undefined = queryClient.getQueryData(queryKey);
           prevData = prevPostData;
-          if (prevPostData && Object.keys(prevPostData).length > 7) {
+          if (prevPostData && Object.keys(queryKey[1]).length === 2) {
             const newPostData = (
               prevPostData as PostWithPagenation
             )?.content.map((post) => {
@@ -144,7 +152,7 @@ const HeartButton = ({ isLiked, postId }: HeartButtonProps) => {
             });
 
             queryClient.setQueryData(queryKey, newPostData);
-          } else {
+          } else if (prevPostData && Object.keys(queryKey[1]).length === 1) {
             const realUpdatedData = (
               prevPostData as InfiniteData<PostWithPagenation, unknown>
             )?.pages.map((page) => {

--- a/src/pages/CreatePostPage/CreatePostPage.tsx
+++ b/src/pages/CreatePostPage/CreatePostPage.tsx
@@ -76,7 +76,7 @@ const CreatePostPage = () => {
   };
 
   const onTagEnter = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && e.nativeEvent.isComposing === false) {
       e.preventDefault();
 
       if (!tags.includes(tag)) {


### PR DESCRIPTION
## 💡 작업 내용

- [x] fix: 태그 추가에서 한글 입력시 마지막 글자 두 번 입력되는 버그 수정

## 💡 자세한 설명
- 성현님이 말씀해 주신 것 처럼 enter에 isComposing 추가해서 작업 완료했습니다. 윈도우라서 결과 확인이 불가능 해, 일단 머지해서 배포 후 확인해 보겠습니다.
```javascript
const onTagEnter = (e: KeyboardEvent<HTMLInputElement>) => {
  if (e.key === 'Enter' && e.nativeEvent.isComposing === false) {
    e.preventDefault();

    if (!tags.includes(tag)) {
      const newTag = [...tags, tag];
      setEach('tags', newTag);
    }

    setTag('');
  }
};
```
## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #89 
