### PR TITLE
fix: 게시물 및 댓글 신고 시 발생하는 400 에러 수정

### DIFF
--- a/src/api/comments/comments.ts
+++ b/src/api/comments/comments.ts
@@ -49,7 +49,7 @@ export const fetchReportComment = async (postId: number, commetId: number) => {
   const response = await axiosInstance.post(
     END_POINT.REPORT_COMMENT(postId, commetId),
     {
-      category: '댓글 신고합니다.',
+      category: 'ETC',
       description: '댓글 신고 내용',
     },
   );

--- a/src/api/posts/posts.ts
+++ b/src/api/posts/posts.ts
@@ -128,7 +128,7 @@ export const fetchDeleteBookmark = async (postId: number) => {
 
 export const fetchReportPost = async (postId: number) => {
   const response = await axiosInstance.post(END_POINT.REPORT_POST(postId), {
-    category: '게시글 신고합니다.',
+    category: 'ETC',
     description: '게시글 신고 내용',
   });
   return response;


### PR DESCRIPTION
## 💡 작업 내용
- [x] 게시물 및 댓글 신고 시 발생하는 400 에러 수정

## 💡 자세한 설명
### 🛠 게시물 및 댓글 신고 시 발생하는 400 에러 수정
게시글 및 댓글 신고 시 전달하는 category field의 값을 특정 값으로 지정을 해야 400 에러가 나지 않는다는 사실을
확인하였습니다. 그리하여 여러 값들 중에 우선 하나인 'ETC'를 category 값으로 설정하는 방식으로 error를 해결하였습니다.

#### ✔︎ 수정 전 게시글 신고, 댓글 신고 api fetcher
```ts
export const fetchReportPost = async (postId: number) => {
  const response = await axiosInstance.post(END_POINT.REPORT_POST(postId), {
    category: '게시글 신고합니다.',
    description: '게시글 신고 내용',
  });
  return response;
};

export const fetchReportComment = async (postId: number, commetId: number) => {
  const response = await axiosInstance.post(
    END_POINT.REPORT_COMMENT(postId, commetId),
    {
      category: 'ETC',
      description: '댓글 신고 내용',
    },
  );
  return response;
};
```

#### ✔︎ 수정 후 게시글 신고, 댓글 신고 api fetcher
```ts
export const fetchReportPost = async (postId: number) => {
  const response = await axiosInstance.post(END_POINT.REPORT_POST(postId), {
    category: 'ETC',
    description: '게시글 신고 내용',
  });
  return response;
};

export const fetchReportComment = async (postId: number, commetId: number) => {
  const response = await axiosInstance.post(
    END_POINT.REPORT_COMMENT(postId, commetId),
    {
      category: 'ETC',
      description: '댓글 신고 내용',
    },
  );
  return response;
};
```
## 🚩 후속 작업 (선택)
본인이 작성한 댓글 및 답글에는 신고할 수 없도록 해야하며, 같은 게시물 및 답글에 연속적으로 신고가 불가능하도록
구현할 필요가 있습니다. 이는 추후에 수정 보완해 나가겠습니다.

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

**closes #87**
