### PR TITLE
feat: 프로필 사진 클릭 시, 프로필 모달을 보여주는 기능 구현

### DIFF
--- a/src/components/common/BalanceOptionCard/BalanceOptionCard.style.ts
+++ b/src/components/common/BalanceOptionCard/BalanceOptionCard.style.ts
@@ -40,7 +40,7 @@ export const winnerIconWrapper = css({
 export const balanceOptionTitleWrapper = css({
   display: 'flex',
   fontFamily: 'SpoqaHanSansNeo-Bold',
-  fontSize: '40px',
+  fontSize: '32px',
   width: '400px',
   height: '100px',
   alignItems: 'center',
@@ -64,7 +64,7 @@ export const balanceOptionDescriptionWrapper = css({
   display: 'flex',
   backgroundColor: '#D9D9D9',
   fontFamily: 'SpoqaHanSansNeo-Bold',
-  fontSize: '1.5rem',
+  fontSize: '1.2rem',
   borderRadius: '1rem',
   padding: '1.5rem 1rem',
   width: '400px',

--- a/src/components/common/Modal/ProfileModal/ProfileModal.style.ts
+++ b/src/components/common/Modal/ProfileModal/ProfileModal.style.ts
@@ -1,0 +1,95 @@
+import { Theme } from '@/styles/Theme';
+import { css } from '@emotion/react';
+
+import { Member } from '@/types/member';
+
+// export const ProfileModalWrapper = css({
+//   position: 'fixed',
+//   top: '50%',
+//   left: '50%',
+//   display: 'flex',
+//   padding: '50px 40px',
+//   flexDirection: 'column',
+//   alignItems: 'center',
+//   gap: '40px',
+//   borderRadius: '10px',
+//   background: 'white',
+//   zIndex: '300',
+//   transform: `translate(-50%, -50%)`,
+// });
+
+export const profileModalWrapper = css({
+  position: 'fixed',
+  width: '400px',
+  height: '520px',
+  top: '50%',
+  left: '50%',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  borderRadius: '10px',
+  background: 'white',
+  zIndex: '300',
+  gap: '15px',
+  padding: '1rem',
+  transform: `translate(-50%, -50%)`,
+  boxShadow: '0px 4px 4px 0px gray',
+});
+
+export const blankWrapper = css({
+  width: '1px',
+  height: '40px',
+});
+
+export const profileBackgroundWrapper = css({
+  position: 'absolute',
+  zIndex: '-1',
+  top: '16px',
+  width: '95%',
+  height: '150px',
+  borderRadius: '16px',
+  background: '#222831',
+});
+
+export const btnsWrapper = css({
+  display: 'flex',
+  padding: '0.5rem',
+  gap: '20px',
+
+  '& button': { width: '7.5rem' },
+  justifyContent: 'space-betwee',
+});
+
+export const profileInfoWrapper = css({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const profileTextWrapper = css({
+  fontWeight: '600',
+  fontSize: Theme.text.medium.fontSize,
+});
+
+export const profileRankWrapper = (level: Required<Member>['level']) => {
+  const style = {
+    0: css({
+      '& path': {
+        fill: Theme.color.bronze,
+      },
+    }),
+    1: css({
+      '& path': {
+        fill: Theme.color.silver,
+      },
+    }),
+    2: css({
+      '& path': {
+        fill: Theme.color.gold,
+      },
+    }),
+  };
+
+  return style[level];
+};

--- a/src/components/common/Modal/ProfileModal/ProfileModal.tsx
+++ b/src/components/common/Modal/ProfileModal/ProfileModal.tsx
@@ -1,0 +1,101 @@
+import React, { SetStateAction, useEffect, useRef } from 'react';
+import Button from '@/components/design/Button/Button';
+import { useNavigate } from 'react-router-dom';
+import { PATH } from '@/constants/path';
+import { useNewSelector } from '@/store';
+import { useMemberQuery } from '@/hooks/api/useMemberQuery';
+import { useParseJwt } from '@/hooks/common/useParseJwt';
+import { selectAccessToken } from '@/store/auth';
+import { Rank } from '@/assets';
+import { getYearMonthDay } from '@/utils/date';
+import {
+  profileModalWrapper,
+  profileBackgroundWrapper,
+  profileInfoWrapper,
+  profileRankWrapper,
+  profileTextWrapper,
+  btnsWrapper,
+  blankWrapper,
+} from './ProfileModal.style';
+import defaultProfile from '../../../../assets/images/defaultProfile.png';
+import ProfileImage from '../../Profile/ProfileImage/ProfileImage';
+import ProfileInfo from '../../Profile/ProfileInfo';
+
+interface ProfileModalProps {
+  handleModal: React.Dispatch<SetStateAction<boolean>>;
+  creatorId: number;
+}
+
+const ProfileModal = ({ handleModal, creatorId }: ProfileModalProps) => {
+  const profileModalRef = useRef<HTMLDivElement>(null);
+  const accessToken = useNewSelector(selectAccessToken);
+  const { member: creator } = useMemberQuery(creatorId);
+  const { member } = useMemberQuery(useParseJwt(accessToken).memberId);
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleOutSideClick = (event: MouseEvent) => {
+      if (
+        profileModalRef.current &&
+        !profileModalRef.current.contains(event.target as Node)
+      ) {
+        handleModal(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleOutSideClick);
+
+    return () => {
+      document.removeEventListener('mousedown', handleOutSideClick);
+    };
+  }, [profileModalRef, handleModal]);
+  if (!member) return null;
+
+  return (
+    <div ref={profileModalRef} css={profileModalWrapper}>
+      {creator && (
+        <>
+          <div css={blankWrapper} />
+          <div css={profileBackgroundWrapper} />
+          <ProfileImage
+            src={
+              creator?.profileImageUrl
+                ? creator?.profileImageUrl
+                : defaultProfile
+            }
+            size="large"
+            isOutline
+          />
+
+          <ProfileInfo title={`가입일: ${getYearMonthDay(creator?.createdAt)}`}>
+            <p css={profileTextWrapper}>{creator?.nickname}</p>
+          </ProfileInfo>
+          <div css={profileInfoWrapper}>
+            <ProfileInfo title="작성한 게시글">
+              <p css={profileTextWrapper}>{creator?.postsCount}</p>
+            </ProfileInfo>
+            <ProfileInfo title="추천 수">
+              <p css={profileTextWrapper}>{creator?.totalPostLike}</p>
+            </ProfileInfo>
+            <ProfileInfo title="등급">
+              <Rank css={profileRankWrapper(creator?.level)} />
+            </ProfileInfo>
+          </div>
+        </>
+      )}
+      <div css={btnsWrapper}>
+        {member?.id === creatorId && (
+          <Button onClick={() => navigate(`../${PATH.MYPAGE}/history/posts`)}>
+            마이페이지
+          </Button>
+        )}
+        <Button variant="cancel" onClick={() => handleModal(false)}>
+          닫기
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileModal;

--- a/src/components/common/UserComment/UserComment.style.ts
+++ b/src/components/common/UserComment/UserComment.style.ts
@@ -9,6 +9,12 @@ export const userCommentWrapper = (isAlingLeft: boolean) =>
     padding: '0.8rem',
   });
 
+export const creatorImageWrapper = css({
+  ':hover': {
+    cursor: 'pointer',
+  },
+});
+
 export const commentMainWrapper = (isReply: boolean, isAlignLeft: boolean) =>
   css({
     display: 'inline-flex',

--- a/src/components/common/UserComment/UserComment.tsx
+++ b/src/components/common/UserComment/UserComment.tsx
@@ -20,6 +20,7 @@ import {
   createdAtWrapper,
   editDeletebtnsWrapper,
   likeBtnWrapper,
+  creatorImageWrapper,
   nameWrapper,
   replyBtnWrapper,
   userCommentWrapper,
@@ -30,6 +31,7 @@ import ProfileImage from '../Profile/ProfileImage/ProfileImage';
 import defaultProfile from '../../../assets/images/defaultProfile.png';
 import ReportModal from '../Modal/ReportModal/ReportModal';
 import DeleteCommentModal from '../Modal/DeleteCommentModal/DeleteCommentModal';
+import ProfileModal from '../Modal/ProfileModal/ProfileModal';
 
 type UserCommentProps = Comment & {
   handleLoginModal: React.Dispatch<SetStateAction<boolean>>;
@@ -57,6 +59,7 @@ const UserComment = ({
   alignLeft,
   selectedPageNumber,
   replyCount,
+  writerId,
   handleLoginModal,
   handleOpenReplies,
 }: UserCommentProps) => {
@@ -66,6 +69,7 @@ const UserComment = ({
   const [isActiveEditInput, setIsActiveEditInput] = useState(false);
   const [isReportModalOpoen, setIsReportModalOpen] = useState(false);
   const [isDeleteModalOpoen, setIsDeleteModalOpen] = useState(false);
+  const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
 
   const { member } = useMemberQuery(
     useParseJwt(useNewSelector(selectAccessToken)).memberId,
@@ -82,7 +86,16 @@ const UserComment = ({
     <div css={userCommentWrapper(!!isAlignLeft)}>
       <div css={commentMainWrapper(isReply, !!isAlignLeft)}>
         <div css={commentWrapper(!!isAlignLeft)}>
-          <ProfileImage src={profileImageUrl || defaultProfile} size="small" />
+          <div
+            css={creatorImageWrapper}
+            onClick={() => setIsProfileModalOpen(!isProfileModalOpen)}
+          >
+            <ProfileImage
+              src={profileImageUrl || defaultProfile}
+              size="small"
+            />
+          </div>
+
           <div
             css={commentInfoWrapper(
               isActiveEditInput,
@@ -164,6 +177,13 @@ const UserComment = ({
           commentId={id}
           parentCommentId={parentCommentId}
           handleModal={setIsDeleteModalOpen}
+        />
+      )}
+
+      {isProfileModalOpen && (
+        <ProfileModal
+          creatorId={writerId}
+          handleModal={setIsProfileModalOpen}
         />
       )}
     </div>

--- a/src/pages/PostPage/CreatorSection/CreatorSection.style.ts
+++ b/src/pages/PostPage/CreatorSection/CreatorSection.style.ts
@@ -1,12 +1,17 @@
 import { css } from '@emotion/react';
 
-export const CreatorSectionWrapper = css({
+export const creatorSectionWrapper = css({
   display: 'flex',
   alignItems: 'center',
   gap: '1.3rem',
   padding: '1rem 2rem',
 });
 
+export const creatorImageWrapper = css({
+  ':hover': {
+    cursor: 'pointer',
+  },
+});
 export const creatorInfoWrapper = css({
   display: 'flex',
   flexDirection: 'column',
@@ -21,7 +26,7 @@ export const creatorNameWrapper = css({
   fontSize: '1rem',
 });
 
-export const CreatedDateWrapper = css({
+export const createdDateWrapper = css({
   fontFamily: 'SpoqaHanSansNeo-thin',
   fontSize: '1rem',
 });

--- a/src/pages/PostPage/CreatorSection/CreatorSection.tsx
+++ b/src/pages/PostPage/CreatorSection/CreatorSection.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
-
+import React, { useState } from 'react';
 import { getFormattedDate } from '@/utils/date';
 import ProfileImage from '@/components/common/Profile/ProfileImage/ProfileImage';
+import ProfileModal from '@/components/common/Modal/ProfileModal/ProfileModal';
 import {
-  CreatedDateWrapper,
-  CreatorSectionWrapper,
+  createdDateWrapper,
+  creatorSectionWrapper,
   creatorInfoWrapper,
   creatorNameWrapper,
+  creatorImageWrapper,
 } from './CreatorSection.style';
 import defaultProfile from '../../../assets/images/defaultProfile.png';
 
@@ -14,16 +15,22 @@ interface CreatorSectionProps {
   createdBy: string;
   createdAt: string;
   creatorProfileImageUrl: string | null;
+  creatorId: number;
 }
 
 const CreatorSection = ({
   createdBy,
   createdAt,
   creatorProfileImageUrl,
+  creatorId,
 }: CreatorSectionProps) => {
+  const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
   return (
-    <div css={CreatorSectionWrapper}>
-      <div>
+    <div css={creatorSectionWrapper}>
+      <div
+        css={creatorImageWrapper}
+        onClick={() => setIsProfileModalOpen(!isProfileModalOpen)}
+      >
         <ProfileImage
           src={creatorProfileImageUrl || defaultProfile}
           size="small"
@@ -33,8 +40,14 @@ const CreatorSection = ({
       <div css={creatorInfoWrapper}>
         <div css={creatorNameWrapper} />
         {createdBy || 'nickname'}
-        <div css={CreatedDateWrapper}>{getFormattedDate(createdAt)}</div>
+        <div css={createdDateWrapper}>{getFormattedDate(createdAt)}</div>
       </div>
+      {isProfileModalOpen && (
+        <ProfileModal
+          creatorId={creatorId}
+          handleModal={setIsProfileModalOpen}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/PostPage/PostPage.tsx
+++ b/src/pages/PostPage/PostPage.tsx
@@ -25,7 +25,6 @@ const PostPage = () => {
   });
 
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
-  console.log(post);
 
   return !post ? (
     <div />
@@ -53,6 +52,7 @@ const PostPage = () => {
             createdBy={post?.createdBy}
             createdAt={post?.createdAt}
             creatorProfileImageUrl={post?.profileImageUrl}
+            creatorId={post?.writerId}
           />
         )}
         <UserUtilitySection

--- a/src/pages/PostPage/TitleSection/TitleSection.tsx
+++ b/src/pages/PostPage/TitleSection/TitleSection.tsx
@@ -30,7 +30,9 @@ const TitleSection = ({
     <div css={titleSectionWrapper}>
       <div css={titleSectionLeftWrapper}>
         <div css={titleWrapper}>
-          <div css={categoryWrapper}>{category}</div>
+          <div css={categoryWrapper}>
+            {category === 'CASUAL' ? '캐쥬얼' : '토론'}
+          </div>
           <div>{title}</div>
         </div>
         <div css={tagsWrapper}>

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -12,6 +12,7 @@ export type Comment = {
   profileImageUrl: string | null;
   postTitle?: string;
   replyCount?: number;
+  writerId: number;
 };
 
 export type CreatedComment = Pick<Comment, 'content' | 'selectedOptionId'>;

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -46,6 +46,7 @@ export type NPost = {
   createdAt: string;
   createdBy: string;
   selectedOptionId?: number | null;
+  writerId: number;
   profileImageUrl: string | null;
 };
 


### PR DESCRIPTION
## 💡 작업 내용
- [x] 게시글 본문의 선택지 옵션과 description 글자 크기 수정하여, 칸을 넘지않도록 조정
- [x] 프로필 사진 클릭 시, 프로필 모달을 보여주는 기능 구현

## 💡 자세한 설명
### 🛠 게시글 본문의 선택지 옵션과 description 글자 크기 수정하여, 칸을 넘지않도록 조정
게시글 본문의 선택지 옵션과 description 글자 크기를 수정하여, 칸을 넘지않도록 하였습니다.
<br>
#### 🎬 칸을 넘지 않도록 수정한 게시물 선택지 카드
<img width="500" alt="image" src="https://github.com/CHZZK-Study/Balance-Talk-Frontend/assets/62270427/7b2f31c1-14c8-460d-b9bc-d3c26bee0570">

<br>

### 🛠 프로필 사진 클릭 시, 프로필 모달을 보여주는 기능 구현
프로필 사진 클릭 시, 게시글 작성자 또는 댓글 작성자의 프로필을 보여주는 모달을 구현하였습니다.
작성자가 자신과 같을 경우, 마이페이지로 이동할 수 있는 마이페이지 버튼이 활성화되도록 구현하였습니다.
현재 비회원 상태일 때 프로필 조회가 안되는 버그가 있어서 추후 수정이 필요할 것 같습니다.

```tsx
// ProfileModal.tsx
...
interface ProfileModalProps {
  handleModal: React.Dispatch<SetStateAction<boolean>>;
  creatorId: number;
}

const ProfileModal = ({ handleModal, creatorId }: ProfileModalProps) => {
  const profileModalRef = useRef<HTMLDivElement>(null);
  const accessToken = useNewSelector(selectAccessToken);
  const { member: creator } = useMemberQuery(creatorId);
  const { member } = useMemberQuery(useParseJwt(accessToken).memberId);

  const navigate = useNavigate();
... 

  return (
    <div ref={profileModalRef} css={profileModalWrapper}>
      {creator && (
        <>
          <div css={blankWrapper} />
          <div css={profileBackgroundWrapper} />
          <ProfileImage
            src={
              creator?.profileImageUrl
                ? creator?.profileImageUrl
                : defaultProfile
            }
            size="large"
            isOutline
          />

          <ProfileInfo title={`가입일: ${getYearMonthDay(creator?.createdAt)}`}>
            <p css={profileTextWrapper}>{creator?.nickname}</p>
          </ProfileInfo>
          <div css={profileInfoWrapper}>
            <ProfileInfo title="작성한 게시글">
              <p css={profileTextWrapper}>{creator?.postsCount}</p>
            </ProfileInfo>
            <ProfileInfo title="추천 수">
              <p css={profileTextWrapper}>{creator?.totalPostLike}</p>
            </ProfileInfo>
            <ProfileInfo title="등급">
              <Rank css={profileRankWrapper(creator?.level)} />
            </ProfileInfo>
          </div>
        </>
      )}
      <div css={btnsWrapper}>
        {member?.id === creatorId && (
          <Button onClick={() => navigate(`../${PATH.MYPAGE}/history/posts`)}>
            마이페이지
          </Button>
        )}
        <Button variant="cancel" onClick={() => handleModal(false)}>
          닫기
        </Button>
      </div>
    </div>
  );
};

export default ProfileModal;

```
#### 🎬 작성자가 본인이 아닐 경우 프로필 모달

<img width="400" alt="image" src="https://github.com/CHZZK-Study/Balance-Talk-Frontend/assets/62270427/7e48fb45-a0b7-488f-a70c-c62118242015">
<br>

#### 🎬 작성자가 본인일 경우 프로필 모달
<img width="400" alt="image" src="https://github.com/CHZZK-Study/Balance-Talk-Frontend/assets/62270427/fb559d74-25b8-48d1-a40e-77d1a070ef08">


## 🚩 후속 작업
- 현재 답글 조회 시, 작성자의 id 값인 writerId가 false로 받아와져, 프로필 모달이 보여지지 않는 상황입니다. 백엔드 분들과 이야기를
나눈 후, 수정하겠습니다.
- 비회원 상태시 프로필 조회가 안되는 상황입니다. 이 부분도 백엔드 분들과 이야기를 나눌 예정입니다.
- 신고 부분에 대한 구현이 완료되지 않았습니다. 마무리 하겠습니다.

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

**closes #102**
