### PR TITLE
feat : 신고 이력이 있거나 본인이 작성한 게시글/댓글의 신고 버튼을 눌렀을 때, 신고가 불가함을 알려주는 기능 구현

### DIFF
--- a/src/components/Buttons/CommentReportButton.tsx
+++ b/src/components/Buttons/CommentReportButton.tsx
@@ -12,6 +12,9 @@ import { pulsate } from '../../styles/keyframes';
 type CommentReportButtonProps = {
   handleLoginModal: React.Dispatch<SetStateAction<boolean>>;
   handleReportModal: React.Dispatch<SetStateAction<boolean>>;
+  handleReportErrorType: React.Dispatch<
+    SetStateAction<'CONFLICT' | 'FORBIDDEN' | null>
+  >;
   commentId: number;
   postId: number;
 };
@@ -19,6 +22,7 @@ type CommentReportButtonProps = {
 const CommentReportButton = ({
   handleLoginModal,
   handleReportModal,
+  handleReportErrorType,
   commentId,
   postId,
 }: CommentReportButtonProps) => {
@@ -42,6 +46,10 @@ const CommentReportButton = ({
       _commentId: number;
     }) => fetchReportComment(_postId, _commentId),
     onSuccess: () => handleReportModal(true),
+    onError: (e: { httpStatus: 'CONFLICT' | 'FORBIDDEN'; message: string }) => {
+      handleReportErrorType(e.httpStatus);
+      handleReportModal(true);
+    },
   });
 
   const handleCommentReport = () => {

--- a/src/components/Buttons/PostReportButton.tsx
+++ b/src/components/Buttons/PostReportButton.tsx
@@ -12,12 +12,16 @@ import { pulsate } from '../../styles/keyframes';
 type PostReportButtonProps = {
   handleLoginModal: React.Dispatch<SetStateAction<boolean>>;
   handleReportModal: React.Dispatch<SetStateAction<boolean>>;
+  handleReportErrorType: React.Dispatch<
+    SetStateAction<'CONFLICT' | 'FORBIDDEN' | null>
+  >;
   postId: number;
 };
 
 const PostReportButton = ({
   handleLoginModal,
   handleReportModal,
+  handleReportErrorType,
   postId,
 }: PostReportButtonProps) => {
   const { member } = useMemberQuery(
@@ -34,6 +38,10 @@ const PostReportButton = ({
   const reportPost = useMutation({
     mutationFn: fetchReportPost,
     onSuccess: () => handleReportModal(true),
+    onError: (e: { httpStatus: 'CONFLICT' | 'FORBIDDEN'; message: string }) => {
+      handleReportErrorType(e.httpStatus);
+      handleReportModal(true);
+    },
   });
 
   const handlePostReport = () => {

--- a/src/components/common/Modal/ReportModal/ReportModal.tsx
+++ b/src/components/common/Modal/ReportModal/ReportModal.tsx
@@ -6,12 +6,21 @@ import {
   titleWrapper,
 } from './ReportModal.style';
 
-interface ChangeVoteModalProps {
+interface ReportModalProps {
   handleModal: React.Dispatch<SetStateAction<boolean>>;
+  handleReportErrorType: React.Dispatch<
+    SetStateAction<'CONFLICT' | 'FORBIDDEN' | null>
+  >;
   type: '게시글' | '댓글';
+  errorType?: 'CONFLICT' | 'FORBIDDEN' | null;
 }
 
-const ReportModal = ({ handleModal, type }: ChangeVoteModalProps) => {
+const ReportModal = ({
+  handleModal,
+  handleReportErrorType,
+  type,
+  errorType,
+}: ReportModalProps) => {
   const reportModalRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -20,6 +29,7 @@ const ReportModal = ({ handleModal, type }: ChangeVoteModalProps) => {
         reportModalRef.current &&
         !reportModalRef.current.contains(event.target as Node)
       ) {
+        handleReportErrorType(null);
         handleModal(false);
       }
     };
@@ -29,13 +39,25 @@ const ReportModal = ({ handleModal, type }: ChangeVoteModalProps) => {
     return () => {
       document.removeEventListener('mousedown', handleOutSideClick);
     };
-  }, [reportModalRef, handleModal]);
+  }, [reportModalRef, handleModal, handleReportErrorType]);
 
   return (
     <div ref={reportModalRef} css={reportModalWrapper}>
-      <div css={titleWrapper}>{type} 신고가 접수되었습니다.</div>
+      <div css={titleWrapper}>
+        {errorType === null
+          ? `${type} 신고가 접수되었습니다.`
+          : errorType === 'CONFLICT'
+            ? `이미 신고한 ${type}입니다.`
+            : `본인 ${type}을 신고할 수 없습니다.`}
+      </div>
       <div css={btnsWrapper}>
-        <Button variant="cancel" onClick={() => handleModal(false)}>
+        <Button
+          variant="cancel"
+          onClick={() => {
+            handleReportErrorType(null);
+            handleModal(false);
+          }}
+        >
           닫기
         </Button>
       </div>

--- a/src/components/common/UserComment/UserComment.tsx
+++ b/src/components/common/UserComment/UserComment.tsx
@@ -70,6 +70,9 @@ const UserComment = ({
   const [isReportModalOpoen, setIsReportModalOpen] = useState(false);
   const [isDeleteModalOpoen, setIsDeleteModalOpen] = useState(false);
   const [isProfileModalOpen, setIsProfileModalOpen] = useState(false);
+  const [reportErrorType, setIsReportErrorType] = useState<
+    'FORBIDDEN' | 'CONFLICT' | null
+  >(null);
 
   const { member } = useMemberQuery(
     useParseJwt(useNewSelector(selectAccessToken)).memberId,
@@ -148,6 +151,7 @@ const UserComment = ({
               handleLoginModal={handleLoginModal}
               commentId={id}
               handleReportModal={setIsReportModalOpen}
+              handleReportErrorType={setIsReportErrorType}
             />
           </div>
           {!parentCommentId && (
@@ -169,7 +173,12 @@ const UserComment = ({
         </div>
       </div>
       {isReportModalOpoen && (
-        <ReportModal handleModal={setIsReportModalOpen} type="댓글" />
+        <ReportModal
+          handleModal={setIsReportModalOpen}
+          type="댓글"
+          errorType={reportErrorType}
+          handleReportErrorType={setIsReportErrorType}
+        />
       )}
       {isDeleteModalOpoen && (
         <DeleteCommentModal

--- a/src/pages/PostPage/UserUtilitySection/UserUtilitySection.tsx
+++ b/src/pages/PostPage/UserUtilitySection/UserUtilitySection.tsx
@@ -26,6 +26,9 @@ const UserUtilitySection = ({
   postId,
 }: UserUtilitySectionProps) => {
   const [isReportModalOpoen, setIsReportModalOpen] = useState(false);
+  const [reportErrorType, setIsReportErrorType] = useState<
+    'FORBIDDEN' | 'CONFLICT' | null
+  >(null);
   return (
     <div css={UserUtilitySectionWrapper}>
       <div css={UtilityButtonsWrapper}>
@@ -49,11 +52,17 @@ const UserUtilitySection = ({
             handleLoginModal={handleLoginModal}
             handleReportModal={setIsReportModalOpen}
             postId={postId}
+            handleReportErrorType={setIsReportErrorType}
           />
         </div>
       </div>
       {isReportModalOpoen && (
-        <ReportModal handleModal={setIsReportModalOpen} type="게시글" />
+        <ReportModal
+          handleModal={setIsReportModalOpen}
+          handleReportErrorType={setIsReportErrorType}
+          type="게시글"
+          errorType={reportErrorType}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## 💡 작업 내용
- [x] 회원 상태일 때, 답글 작성자의 프로필을 조회하는 기능 버그 수정 확인
- [x] 신고 이력이 있거나 본인이 작성한 게시글의 신고 버튼을 눌렀을 때, 신고가 불가함을 알려주는 기능 구현
- [x] 신고 이력이 있거나 본인이 작성한 댓글의 신고 버튼을 눌렀을 때, 신고가 불가함을 알려주는 기능 구현

## 💡 자세한 설명

### 🛠.회원 상태일 때, 답글 작성자의 프로필을 조회하는 기능 버그 수정 확인
답글 작성자의 프로필 조회가 안되었던 버그가 수정된 부분 확인하였습니다.
#### 🎬 답글 작성자 프로필 조회
<img width="500" alt="image" src="https://github.com/CHZZK-Study/Balance-Talk-Frontend/assets/62270427/5e4e3e71-6f30-4725-b2cf-2372c46f7c74"><br>

### 🛠 신고 이력이 있거나 본인이 작성한 게시글의 신고 버튼을 눌렀을 때, 신고가 불가함을 알려주는 기능 구현

#### ✔︎ 게시물의 신고 버튼이 위치한 UserUtiltiySection에 errorType state 설정
신고 시 발생하는 error를 type에 따라 처리하기 위해 게시물 신고 버튼의 상위 컴포넌트인 `UserUtilitySection`에
신고 에러 타입 State(`reportErrorType`)를 선언하였고, `setIsReportErrorType`를 `PostReportButton`컴포넌트와
`ReportModal`컴포넌트의 `handleReportError` props로 넘겨주었습니다.
```tsx
// UserUtilitySection.tsx
....
const UserUtilitySection = ({
  likesCount,
  myBookmark,
  handleLoginModal,
  myLike,
  postId,
}: UserUtilitySectionProps) => {
  const [isReportModalOpoen, setIsReportModalOpen] = useState(false);
  const [reportErrorType, setIsReportErrorType] = useState<
    'FORBIDDEN' | 'CONFLICT' | null
  >(null);
  return (
    <div css={UserUtilitySectionWrapper}>
      <div css={UtilityButtonsWrapper}>
           .......
        <div css={utilityBtnsWrapper}>
          <PostReportButton
            handleLoginModal={handleLoginModal}
            handleReportModal={setIsReportModalOpen}
            postId={postId}
            handleReportErrorType={setIsReportErrorType}
          />
        </div>
      </div>
      {isReportModalOpoen && (
        <ReportModal
          handleModal={setIsReportModalOpen}
          handleReportErrorType={setIsReportErrorType}
          type="게시글"
          errorType={reportErrorType}
        />
      )}
    </div>
  );
};

export default UserUtilitySection;

```
#### ✔︎ PostReportButton에서의 신고 에러 처리
useMutation의 onError를 통해 신고 Request에 대한 응답의 httpStatus를 ReportErrorType으로 설정하였습니다.

```tsx
//PostReportButton.tsx

type PostReportButtonProps = {
.....
  handleReportErrorType: React.Dispatch<
    SetStateAction<'CONFLICT' | 'FORBIDDEN' | null>
  >;
...
};

const PostReportButton = ({
  handleLoginModal,
  handleReportModal,
  handleReportErrorType,
  postId,
}: PostReportButtonProps) => {
  const reportPost = useMutation({
    mutationFn: fetchReportPost,
    onSuccess: () => handleReportModal(true),
    onError: (e: { httpStatus: 'CONFLICT' | 'FORBIDDEN'; message: string }) => {
      handleReportErrorType(e.httpStatus);
      handleReportModal(true);
    },
  });
......
```
#### ✔︎ ReportModal에서의 에러 처리
ReportModal에 errorType과 handleReportErrorType handler를 전달하여, errorType에 따라서 모달의 제목 텍스트가
다르게 보이도록 구현하였습니다. 또한 모달의 외부를 클릭하거나 닫기 버튼을 클릭하여 모달을 닫을 때, `handleReportErrorType(null)`
을 통해 errorType을 null로 초기화하였습니다.

```tsx
// ReportModal.tsx
...
interface ReportModalProps {
 ....
  handleReportErrorType: React.Dispatch<
    SetStateAction<'CONFLICT' | 'FORBIDDEN' | null>
  >;
  type: '게시글' | '댓글';
  errorType?: 'CONFLICT' | 'FORBIDDEN' | null;
}

const ReportModal = ({
  handleModal,
  handleReportErrorType,
  type,
  errorType,
}: ReportModalProps) => {
  const reportModalRef = useRef<HTMLDivElement>(null);

  useEffect(() => {
    const handleOutSideClick = (event: MouseEvent) => {
      if (
        reportModalRef.current &&
        !reportModalRef.current.contains(event.target as Node)
      ) {
        handleReportErrorType(null);
        handleModal(false);
      }
    };
    document.addEventListener('mousedown', handleOutSideClick);

    return () => {
      document.removeEventListener('mousedown', handleOutSideClick);
    };
  }, [reportModalRef, handleModal, handleReportErrorType]);

  return (
    <div ref={reportModalRef} css={reportModalWrapper}>
      <div css={titleWrapper}>
        {errorType === null
          ? `${type} 신고가 접수되었습니다.`
          : errorType === 'CONFLICT'
            ? `이미 신고한 ${type}입니다.`
            : `본인 ${type}을 신고할 수 없습니다.`}
      </div>
      <div css={btnsWrapper}>
        <Button
          variant="cancel"
          onClick={() => {
            handleReportErrorType(null);
            handleModal(false);
          }}
        >
          닫기
        </Button>
      </div>
    </div>
  );
};
```
### 🛠 신고 이력이 있거나 본인이 작성한 답글의 신고 버튼을 눌렀을 때, 신고가 불가함을 알려주는 기능 구현

#### ✔︎ 댓글 신고 버튼이 위치한 UserComment에 errorType state 설정
신고 시 발생하는 error를 type에 따라 처리하기 위해, 댓글 신고 버튼의 상위 컴포넌트인 `UserComment`에
신고 에러 타입 State(`reportErrorType`)를 선언하였고, `setIsReportErrorType`를 `CommentReportButton`컴포넌트와
`ReportModal`컴포넌트의 `handleReportError` props로 넘겨주었습니다.

```tsx
// UserComment.tsx

const UserComment = ({
 .....
}: UserCommentProps) => {
  const [reportErrorType, setIsReportErrorType] = useState<
    'FORBIDDEN' | 'CONFLICT' | null
  >(null);

  return (
    <div css={userCommentWrapper(!!isAlignLeft)}>
      <div css={commentMainWrapper(isReply, !!isAlignLeft)}>
       .....
        <div css={btnsWrapper(!!isAlignLeft)}>
          <div css={utilityBtnsWrapper}>
            ,,,,,
            <CommentReportButton
              postId={postId}
              handleLoginModal={handleLoginModal}
              commentId={id}
              handleReportModal={setIsReportModalOpen}
              handleReportErrorType={setIsReportErrorType}
            />
          </div>
           ....
            
      </div>
      {isReportModalOpoen && (
        <ReportModal
          handleModal={setIsReportModalOpen}
          type="댓글"
          errorType={reportErrorType}
          handleReportErrorType={setIsReportErrorType}
        />
      )}
   .....
  );
};
```

#### ✔︎ CommentReportButton에서의 신고 에러 처리
useMutation의 onError를 통해 신고 Request에 대한 응답의 httpStatus를 ReportErrorType으로 설정하였습니다.

```tsx
//CommentReportButton.tsx

type CommentReportButtonProps = {
  handleLoginModal: React.Dispatch<SetStateAction<boolean>>;
  handleReportModal: React.Dispatch<SetStateAction<boolean>>;
  handleReportErrorType: React.Dispatch<
    SetStateAction<'CONFLICT' | 'FORBIDDEN' | null>
  >;
  commentId: number;
  postId: number;
};

const CommentReportButton = ({
  handleLoginModal,
  handleReportModal,
  handleReportErrorType,
  commentId,
  postId,
}: CommentReportButtonProps) => {

  const reportComment = useMutation({
    mutationFn: ({
      _postId,
      _commentId,
    }: {
      _postId: number;
      _commentId: number;
    }) => fetchReportComment(_postId, _commentId),
    onSuccess: () => handleReportModal(true),
    onError: (e: { httpStatus: 'CONFLICT' | 'FORBIDDEN'; message: string }) => {
      handleReportErrorType(e.httpStatus);
      handleReportModal(true);
    },
  });
   .....
};
export default CommentReportButton;
```

### 🛠 신고 테스트

#### 🎬 본인이 작성한 게시물 신고 테스트
<img width="500" alt="image" src="https://github.com/CHZZK-Study/Balance-Talk-Frontend/assets/62270427/c8106e30-e433-4224-951e-71ec4f5cf3c5"><br>

#### 🎬 신고 이력이 있는 게시물 신고 테스트
<img width="500" alt="image" src="https://github.com/CHZZK-Study/Balance-Talk-Frontend/assets/62270427/d3c76c3c-aa7a-4e44-9933-175eee2bc065"><br>

#### 🎬 본인이 작성한 댓글 신고 테스트
<img width="500" alt="image" src="https://github.com/CHZZK-Study/Balance-Talk-Frontend/assets/62270427/df837837-0ad9-4bd7-8932-3868abd7d3de"><br>

#### 🎬 신고 이력이 있는 댓글 신고 테스트
<img width="500" alt="image" src="https://github.com/CHZZK-Study/Balance-Talk-Frontend/assets/62270427/7c8ac85b-e9ce-4827-9ea4-77ec9ff6fc21"><br>

## 📢 리뷰 요구 사항
### 🤔 비회원 상태일 때 프로필 조회 시, 여전히 401 Unauthorized 에러 발생
#### 🎬 401 Unauthorized 에러 상황
<img width="500" alt="image" src="https://github.com/CHZZK-Study/Balance-Talk-Frontend/assets/62270427/ee7afa04-e798-4479-8222-f6629cccbd7c"><br>

#### ✔︎ 프로필 조회 시, Response
<img width="500" alt="image" src="https://github.com/CHZZK-Study/Balance-Talk-Frontend/assets/62270427/b773be24-2037-4b3f-994e-36adcb68fb6b"><br>
<img width="500" alt="image" src="https://github.com/CHZZK-Study/Balance-Talk-Frontend/assets/62270427/6d38046c-83a9-420c-b4a7-41e7adb7791f">

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

**closes #104**
**closes #105**
