### PR TITLE
design: Chips 및 상단 배너 컴포넌트 UI 구현

### DIFF
--- a/src/components/common/Chips/Chips.style.ts
+++ b/src/components/common/Chips/Chips.style.ts
@@ -5,13 +5,13 @@ import type { ChipsProps } from './Chips';
 
 export const getSizeStyling = (size: Required<ChipsProps>['size']) => {
   const style = {
-    large: css(typo.Body.SemiBold_1, {
-      padding: '12px 16px',
-      borderRadius: '15px',
+    large: css(typo.Body.SemiBold_5, {
+      padding: '6px 12px',
+      borderRadius: '8px',
     }),
-    small: css(typo.Body.Medium_2, {
-      padding: '7px 12px',
-      borderRadius: '12px',
+    small: css(typo.Body.Medium_5, {
+      padding: '2px 8px',
+      borderRadius: '6px',
     }),
   };
 
@@ -24,6 +24,6 @@ export const chipsStyling = css({
   alignItems: 'center',
   width: 'fit-content',
   backgroundColor: color.Primary[400],
-  color: color.Common[100],
+  color: color.Neutral[50],
   cursor: 'pointer',
 });

--- a/src/components/common/Chips/Chips.style.ts
+++ b/src/components/common/Chips/Chips.style.ts
@@ -5,10 +5,9 @@ import type { ChipsProps } from './Chips';
 
 export const getSizeStyling = (size: Required<ChipsProps>['size']) => {
   const style = {
-    large: css({
+    large: css(typo.Body.SemiBold_1, {
       padding: '12px 16px',
       borderRadius: '15px',
-      fontSize: typo.Body.SemiBold_1.fontSize,
     }),
     small: css(typo.Body.Medium_2, {
       padding: '7px 12px',
@@ -23,6 +22,7 @@ export const chipsStyling = css({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
+  width: 'fit-content',
   backgroundColor: color.Primary[400],
   color: color.Common[100],
   cursor: 'pointer',

--- a/src/components/common/Chips/Chips.style.ts
+++ b/src/components/common/Chips/Chips.style.ts
@@ -23,7 +23,7 @@ export const chipsStyling = css({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  backgroundColor: color.Primary['400'],
-  color: color.Common['100'],
+  backgroundColor: color.Primary[400],
+  color: color.Common[100],
   cursor: 'pointer',
 });

--- a/src/components/common/Chips/Chips.style.ts
+++ b/src/components/common/Chips/Chips.style.ts
@@ -1,0 +1,29 @@
+import { css } from '@emotion/react';
+import typo from '@/styles/typo';
+import color from '@/styles/color';
+import type { ChipsProps } from './Chips';
+
+export const getSizeStyling = (size: Required<ChipsProps>['size']) => {
+  const style = {
+    large: css({
+      padding: '12px 16px',
+      borderRadius: '15px',
+      fontSize: typo.Body.SemiBold_1.fontSize,
+    }),
+    small: css(typo.Body.Medium_2, {
+      padding: '7px 12px',
+      borderRadius: '12px',
+    }),
+  };
+
+  return style[size];
+};
+
+export const chipsStyling = css({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  backgroundColor: color.Primary['400'],
+  color: color.Common['100'],
+  cursor: 'pointer',
+});

--- a/src/components/common/Chips/Chips.tsx
+++ b/src/components/common/Chips/Chips.tsx
@@ -1,0 +1,17 @@
+/* eslint-disable react/react-in-jsx-scope */
+import { ReactNode } from 'react';
+import type { Size } from '@/types/temp';
+import { chipsStyling, getSizeStyling } from './Chips.style';
+
+export interface ChipsProps {
+  size?: Extract<Size, 'small' | 'large'>;
+  children?: ReactNode;
+}
+
+const Chips = ({ size = 'large', children }: ChipsProps) => (
+  <div css={[chipsStyling, getSizeStyling(size), { width: 'fit-content' }]}>
+    {children}
+  </div>
+);
+
+export default Chips;

--- a/src/components/common/Chips/Chips.tsx
+++ b/src/components/common/Chips/Chips.tsx
@@ -9,9 +9,7 @@ export interface ChipsProps {
 }
 
 const Chips = ({ size = 'large', children }: ChipsProps) => (
-  <div css={[chipsStyling, getSizeStyling(size), { width: 'fit-content' }]}>
-    {children}
-  </div>
+  <div css={[chipsStyling, getSizeStyling(size)]}>{children}</div>
 );
 
 export default Chips;

--- a/src/components/pattern/TopBanner/TopBanner.style.ts
+++ b/src/components/pattern/TopBanner/TopBanner.style.ts
@@ -1,0 +1,40 @@
+/* eslint-disable import/no-cycle */
+import { css } from '@emotion/react';
+import typo from '@/styles/typo';
+import color from '@/styles/color';
+import { loadingStyle } from '@/styles/keyframes';
+
+export const loadingStyling = css`
+  animation: ${loadingStyle} 2s infinite;
+`;
+
+export const hideInfo = css({
+  visibility: 'hidden',
+});
+
+export const bannerStyling = css({
+  display: 'flex',
+  flexDirection: 'column-reverse',
+  width: '100%',
+  minHeight: '320px',
+  padding: '23px',
+  borderRadius: '18px',
+  backgroundColor: color.Neutral['800'],
+  cursor: 'pointer',
+});
+
+export const bannerInfoWrapper = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '10px',
+});
+
+export const bannerTitle = css(typo.Heading_2, {
+  color: color.Common['100'],
+});
+
+export const bannerSummary = css(typo.Body.Medium_1, {
+  gap: '5px',
+  color: color.Neutral[400],
+  whiteSpace: 'pre-line',
+});

--- a/src/components/pattern/TopBanner/TopBanner.style.ts
+++ b/src/components/pattern/TopBanner/TopBanner.style.ts
@@ -16,11 +16,17 @@ export const bannerStyling = css({
   display: 'flex',
   flexDirection: 'column-reverse',
   width: '100%',
-  minHeight: '320px',
-  padding: '23px',
-  borderRadius: '18px',
+  minHeight: '297px',
+  padding: '30px',
+  borderRadius: '20px',
   backgroundColor: color.Neutral[800],
   cursor: 'pointer',
+});
+
+export const bannerWrapper = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6px',
 });
 
 export const bannerInfoWrapper = css({
@@ -30,11 +36,10 @@ export const bannerInfoWrapper = css({
 });
 
 export const bannerTitle = css(typo.Heading_2, {
-  color: color.Common[100],
+  color: color.Neutral[50],
 });
 
 export const bannerSummary = css(typo.Body.Medium_1, {
-  gap: '5px',
   color: color.Neutral[400],
   whiteSpace: 'pre-line',
 });

--- a/src/components/pattern/TopBanner/TopBanner.style.ts
+++ b/src/components/pattern/TopBanner/TopBanner.style.ts
@@ -19,7 +19,7 @@ export const bannerStyling = css({
   minHeight: '320px',
   padding: '23px',
   borderRadius: '18px',
-  backgroundColor: color.Neutral['800'],
+  backgroundColor: color.Neutral[800],
   cursor: 'pointer',
 });
 
@@ -30,7 +30,7 @@ export const bannerInfoWrapper = css({
 });
 
 export const bannerTitle = css(typo.Heading_2, {
-  color: color.Common['100'],
+  color: color.Common[100],
 });
 
 export const bannerSummary = css(typo.Body.Medium_1, {

--- a/src/components/pattern/TopBanner/TopBanner.tsx
+++ b/src/components/pattern/TopBanner/TopBanner.tsx
@@ -1,0 +1,29 @@
+/* eslint-disable react/react-in-jsx-scope */
+import { ReactNode } from 'react';
+import Chips from '@/components/common/Chips/Chips';
+import {
+  bannerStyling,
+  bannerInfoWrapper,
+  bannerSummary,
+  bannerTitle,
+  loadingStyling,
+  hideInfo,
+} from './TopBanner.style';
+
+export interface TopBannerProps {
+  title?: ReactNode;
+  summary?: ReactNode;
+  isLoading?: boolean;
+}
+
+const TopBanner = ({ title, summary, isLoading = false }: TopBannerProps) => (
+  <div css={[bannerStyling, isLoading && loadingStyling]}>
+    <div css={[bannerInfoWrapper, isLoading && hideInfo]}>
+      <Chips size="small">오늘의 밸런스톡</Chips>
+      <div css={bannerTitle}>{title}</div>
+      <div css={bannerSummary}>{summary}</div>
+    </div>
+  </div>
+);
+
+export default TopBanner;

--- a/src/components/pattern/TopBanner/TopBanner.tsx
+++ b/src/components/pattern/TopBanner/TopBanner.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 import Chips from '@/components/common/Chips/Chips';
 import {
   bannerStyling,
+  bannerWrapper,
   bannerInfoWrapper,
   bannerSummary,
   bannerTitle,
@@ -18,10 +19,12 @@ export interface TopBannerProps {
 
 const TopBanner = ({ title, summary, isLoading = false }: TopBannerProps) => (
   <div css={[bannerStyling, isLoading && loadingStyling]}>
-    <div css={[bannerInfoWrapper, isLoading && hideInfo]}>
-      <Chips size="small">오늘의 밸런스톡</Chips>
-      <div css={bannerTitle}>{title}</div>
-      <div css={bannerSummary}>{summary}</div>
+    <div css={[bannerWrapper, isLoading && hideInfo]}>
+      <Chips size="large">오늘의 톡픽</Chips>
+      <div css={bannerInfoWrapper}>
+        <div css={bannerTitle}>{title}</div>
+        <div css={bannerSummary}>{summary}</div>
+      </div>
     </div>
   </div>
 );

--- a/src/stories/common/Button.stories.tsx
+++ b/src/stories/common/Button.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { storyContainer, storyInnerContainer } from '@/stories/story.styles';
 
 const meta = {
-  title: 'Button',
+  title: 'commons/Button',
   component: Button,
   parameters: {
     layout: 'centered',

--- a/src/stories/common/Chips.stories.tsx
+++ b/src/stories/common/Chips.stories.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import Chips from '@/components/common/Chips/Chips';
+import type { Meta, StoryObj } from '@storybook/react';
+import { storyContainer, storyInnerContainer } from '@/stories/story.styles';
+
+const meta = {
+  title: 'commons/Chips',
+  component: Chips,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      options: ['small', 'large'],
+      control: { type: 'radio' },
+    },
+    children: { control: { type: 'text' } },
+  },
+  args: {
+    size: 'large',
+    children: '오늘의 밸런스톡',
+  },
+} satisfies Meta<typeof Chips>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    size: 'large',
+  },
+};
+
+export const All: Story = {
+  render: (args) => (
+    <ul css={storyContainer}>
+      <li css={storyInnerContainer}>
+        <h3>Size</h3>
+        <Chips {...args} size="small">
+          Small
+        </Chips>
+        <Chips {...args} size="large">
+          Large
+        </Chips>
+      </li>
+    </ul>
+  ),
+};

--- a/src/stories/pattern/TopBanner.stories.tsx
+++ b/src/stories/pattern/TopBanner.stories.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import TopBanner from '@/components/pattern/TopBanner/TopBanner';
+import type { Meta, StoryObj } from '@storybook/react';
+import { storyContainer, storyInnerContainer } from '@/stories/story.styles';
+
+const exampleBanner = {
+  title: '깻잎 논쟁 당신의 선택은?',
+  summary:
+    '1. 저녁 식사 중 남자친구가 친구에게 깻잎을 떼어주자 나는 불편한 감정을 느꼈다. \n2. 집에 돌아와 남자친구에게 솔직하게 말했고, 그는 미안해하며 이해해 주었다. \n3. 친구들과 이 문제를 논의했지만 결론은 나지 않았고, 사람마다 다르게 받아들일 수 있음을 깨달았다.',
+};
+
+const meta = {
+  title: 'patterns/TopBanner',
+  component: TopBanner,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    title: { control: { type: 'text' } },
+    summary: { control: { type: 'text' } },
+    isLoading: { control: { type: 'boolean' } },
+  },
+  args: {
+    title: exampleBanner.title,
+    summary: exampleBanner.summary,
+  },
+} satisfies Meta<typeof TopBanner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: exampleBanner.title,
+    summary: exampleBanner.summary,
+    isLoading: false,
+  },
+};
+
+export const All: Story = {
+  render: (args) => (
+    <ul css={storyContainer}>
+      <li css={storyInnerContainer}>
+        <h3>Default</h3>
+        <TopBanner
+          title={exampleBanner.title}
+          summary={exampleBanner.summary}
+          isLoading={false}
+        />
+        <h3>Loading</h3>
+        <TopBanner {...args} isLoading />
+      </li>
+    </ul>
+  ),
+};

--- a/src/styles/keyframes.ts
+++ b/src/styles/keyframes.ts
@@ -15,12 +15,12 @@ export const pulsate = keyframes({
 
 export const loadingStyle = keyframes({
   '0%': {
-    backgroundColor: color.Neutral['800'],
+    backgroundColor: color.Neutral[800],
   },
   '50%': {
-    backgroundColor: color.Neutral['700'],
+    backgroundColor: color.Neutral[700],
   },
   '100%': {
-    backgroundColor: color.Neutral['800'],
+    backgroundColor: color.Neutral[800],
   },
 });

--- a/src/styles/keyframes.ts
+++ b/src/styles/keyframes.ts
@@ -1,4 +1,5 @@
 import { keyframes } from '@emotion/react';
+import color from './color';
 
 export const pulsate = keyframes({
   '0%': {
@@ -9,5 +10,17 @@ export const pulsate = keyframes({
   },
   '100%': {
     transform: 'scale(1.1)',
+  },
+});
+
+export const loadingStyle = keyframes({
+  '0%': {
+    backgroundColor: color.Neutral['800'],
+  },
+  '50%': {
+    backgroundColor: color.Neutral['700'],
+  },
+  '100%': {
+    backgroundColor: color.Neutral['800'],
   },
 });


### PR DESCRIPTION
## 💡 작업 내용

- [x] Chips 컴포넌트 UI 구현
- [x] 스토리북에 Chips 컴포넌트 추가
- [x] 상단 배너 컴포넌트 UI 구현
- [x] 스토리북에 상단 배너 컴포넌트 추가

## 💡 자세한 설명

✅ 상단 배너 컴포넌트 UI
- 상단 배너의 width 길이를 반응형을 고려하여 `width: 100%`으로 설정해두었습니다.
- 배너의 배경 이미지가 확정된 것 같지 않아 임의로 배경색을 `backgroundColor: color.Neutral['800']`로 지정해두었습니다.
- 로딩 중일 때의 스타일을 위해 `keyframes.ts` 파일에 `loadingStyle`을 추가하였습니다. 추후에 자유롭게 수정, 삭제하셔도 됩니다!
```javascript
export const loadingStyle = keyframes({
  '0%': {
    backgroundColor: color.Neutral['800'],
  },
  '50%': {
    backgroundColor: color.Neutral['700'],
  },
  '100%': {
    backgroundColor: color.Neutral['800'],
  },
});
```
- 스토리북에서의 원활한 컴포넌트 확인을 위해 `TopBanner.stories.tsx` 파일에 `exampleBanner`을 임시로 적어두었습니다.
```javascript
const exampleBanner = {
  title: '깻잎 논쟁 당신의 선택은?',
  summary:
    '1. 저녁 식사 중 남자친구가 친구에게 깻잎을 떼어주자 나는 불편한 감정을 느꼈다. 
    \n2. 집에 돌아와 남자친구에게 솔직하게 말했고, 그는 미안해하며 이해해 주었다. 
    \n3. 친구들과 이 문제를 논의했지만 결론은 나지 않았고, 사람마다 다르게 받아들일 수 있음을 깨달았다.',
};

export const Default: Story = {
  args: {
    title: exampleBanner.title,
    summary: exampleBanner.summary,
    isLoading: false,
  },
};
```

+) 기존의 Button 컴포넌트의 스토리북 경로를 commons 폴더로 이동시켜두었습니다!

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #119
