### PR TITLE
feat: comment api 함수 및 react query hook 작성

### DIFF
--- a/src/api/comments.ts
+++ b/src/api/comments.ts
@@ -1,100 +1,72 @@
+import { END_POINT } from '@/constants/api';
+import { Id, ServerResponse } from '@/types/api';
 import {
   CommentsPagination,
-  CreatedComment,
-  CreatedReply,
-  EditedComment,
-  Replies,
+  CreateCommentProps,
+  CreateReplyProps,
+  EditCommentProps,
 } from '@/types/comment';
-import { END_POINT } from '@/constants/api';
+import { Pageable } from '@/types/pagination';
 import { axiosInstance } from './interceptor';
 
-export const getComments = async (
-  postId: number,
-  pageable: { page: number; size?: number; sort?: string },
-): Promise<CommentsPagination> => {
-  const response = await axiosInstance.get(END_POINT.COMMENTS(postId), {
-    params: { ...pageable, sort: 'createdAt,desc' },
-  });
-  return response.data as CommentsPagination;
-};
-
-export const createComment = async (postId: number, data: CreatedComment) => {
-  const response = await axiosInstance.post(END_POINT.CREATE_COMMENT(postId), {
-    ...data,
-  });
-  return response;
-};
-
-export const fetchAddLikeComment = async (
-  postId: number,
-  commentId: number,
+export const putComment = async (
+  talkPickId: Id,
+  commentId: Id,
+  comment: EditCommentProps,
 ) => {
-  const response = await axiosInstance.post(
-    END_POINT.ADD_LIKE_COMMENT(postId, commentId),
+  const { data } = await axiosInstance.put<ServerResponse>(
+    END_POINT.EDIT_COMMENT(talkPickId, commentId),
+    { ...comment },
   );
-  return response;
+  return data;
 };
 
-export const fetchDeleteLikeComment = async (
-  postId: number,
-  commentId: number,
-) => {
-  const response = await axiosInstance.delete(
-    END_POINT.DELETE_LIKE_COMMENT(postId, commentId),
+export const deleteComment = async (talkPickId: Id, commentId: Id) => {
+  const { data } = await axiosInstance.delete<ServerResponse>(
+    END_POINT.DELETE_COMMENT(talkPickId, commentId),
   );
-  return response;
+  return data;
 };
 
-export const fetchReportComment = async (postId: number, commetId: number) => {
-  const response = await axiosInstance.post(
-    END_POINT.REPORT_COMMENT(postId, commetId),
+export const getComments = async (talkPickId: Id, pageable: Pageable) => {
+  const { data } = await axiosInstance.get<CommentsPagination>(
+    END_POINT.COMMENTS(talkPickId),
     {
-      category: 'ETC',
-      description: '댓글 신고 내용',
+      params: { ...pageable, sort: 'createdAt,desc' },
     },
   );
-  return response;
+  return data;
 };
 
-export const editComment = async (
-  postId: number,
-  commentId: number,
-  data: EditedComment,
+export const postComment = async (
+  talkPickId: Id,
+  comment: CreateCommentProps,
 ) => {
-  const response = await axiosInstance.put(
-    END_POINT.EDIT_COMMENT(postId, commentId),
-    { ...data },
-  );
-  return response;
-};
-
-export const deleteComment = async (postId: number, commentId: number) => {
-  const response = await axiosInstance.delete(
-    END_POINT.DELETE_COMMENT(postId, commentId),
-  );
-  return response;
-};
-
-export const getReplies = async (
-  postId: number,
-  commentId: number,
-): Promise<Replies> => {
-  const response = await axiosInstance.get(
-    END_POINT.COMMENT_REPLILES(postId, commentId),
-  );
-  return response.data as Replies;
-};
-
-export const createReply = async (
-  postId: number,
-  commentId: number,
-  data: CreatedReply,
-) => {
-  const response = await axiosInstance.post(
-    END_POINT.CREATE_REPLY(postId, commentId),
+  const { data } = await axiosInstance.post<ServerResponse>(
+    END_POINT.CREATE_COMMENT(talkPickId),
     {
-      ...data,
+      ...comment,
     },
   );
-  return response;
+  return data;
+};
+
+export const postReply = async (commentId: Id, reply: CreateReplyProps) => {
+  const { data } = await axiosInstance.post<ServerResponse>(
+    END_POINT.CREATE_REPLY(commentId),
+    {
+      ...reply,
+    },
+  );
+  return data;
+};
+
+export const getBestComments = async (talkPickId: Id, pageable: Pageable) => {
+  const { data } = await axiosInstance.get<CommentsPagination>(
+    END_POINT.BEST_COMMENT(talkPickId),
+    {
+      params: { ...pageable, sort: 'createdAt,desc' },
+    },
+  );
+  return data;
 };

--- a/src/api/like.ts
+++ b/src/api/like.ts
@@ -1,0 +1,17 @@
+import { END_POINT } from '@/constants/api';
+import { Id, ServerResponse } from '@/types/api';
+import { axiosInstance } from './interceptor';
+
+export const postLikeComment = async (commentId: Id) => {
+  const { data } = await axiosInstance.post<ServerResponse>(
+    END_POINT.LIKE_COMMENT(commentId),
+  );
+  return data;
+};
+
+export const deleteLikeComment = async (commentId: Id) => {
+  const { data } = await axiosInstance.delete<ServerResponse>(
+    END_POINT.DELETE_LIKE_COMMENT(commentId),
+  );
+  return data;
+};

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,3 +1,5 @@
+import { Id } from '@/types/api';
+
 export const HTTP_STATUS_CODE = {
   OK: 200,
   BAD_REQUEST: 400,
@@ -16,6 +18,7 @@ export const END_POINT = {
   SIGN_UP: '/members/join',
   LOGIN: '/members/login',
   LOGOUT: '/members/logout',
+  REFRESH: '/members/reissue',
   ALL_MEMBERS: '/members',
   MEMBER: (id: number) => `/members/${id}`,
   MEMBER_PROFILE: (id: number) => `/members/${id}/profile`,
@@ -26,34 +29,29 @@ export const END_POINT = {
   EMAIL_VERIFY: '/email/verify',
   EMAIL_REQUEST: '/email/request',
   FIND_PW: '/email/password',
-  POST: (id: number) => `/posts/${id}`,
   MYPAGE_POSTS: '/myPage/history/posts',
   MYPAGE_COMMENTS: '/myPage/history/comments',
   MYPAGE_VOTEDPOSTS: '/myPage/history/votedPosts',
   MYPAGE_BOOKMARKS: '/myPage/history/bookmarks',
-  COMMENTS: (postId: number) => `/posts/${postId}/comments`,
-  CREATE_COMMENT: (postId: number) => `/posts/${postId}/comments`,
-  VOTE_COUNT: (postId: number) => `/posts/${postId}/vote`,
   FILE_UPLOAD: '/files/image/upload',
-  VOTE: (postId: number) => `posts/${postId}/vote`,
-  ADD_BOOKMARK: (postId: number) => `bookmarks/${postId}`,
-  DELETE_BOOKMARK: (postId: number) => `bookmarks/${postId}`,
+  POST: (id: number) => `/posts/${id}`,
   REPORT_POST: (postId: number) => `posts/${postId}/report`,
-  ADD_LIKE_COMMENT: (postId: number, commentId: number) =>
-    `posts/${postId}/comments/${commentId}/likes`,
-  DELETE_LIKE_COMMENT: (postId: number, commentId: number) =>
-    `posts/${postId}/comments/${commentId}/likes`,
-  REPORT_COMMENT: (postId: number, commentId: number) =>
-    `posts/${postId}/comments/${commentId}/report`,
-  REFRESH: '/members/reissue',
-  EDIT_COMMENT: (postId: number, commentId: number) =>
-    `posts/${postId}/comments/${commentId}`,
-  DELETE_COMMENT: (postId: number, commentId: number) =>
-    `posts/${postId}/comments/${commentId}`,
-  COMMENT_REPLILES: (postId: number, commentId: number) =>
-    `posts/${postId}/comments/${commentId}/replies`,
-  CREATE_REPLY: (postId: number, commentId: number) =>
-    `posts/${postId}/comments/${commentId}/replies`,
+  VOTE_COUNT: (postId: number) => `/posts/${postId}/vote`,
+  VOTE: (postId: number) => `posts/${postId}/vote`,
+  COMMENTS: (talkPickId: Id) => `/talks/${talkPickId}/comments`,
+  BEST_COMMENT: (talkPickId: Id) => `talks/${talkPickId}/comments/best`,
+  CREATE_COMMENT: (talkPickId: Id) => `/talks/${talkPickId}/comments`,
+  EDIT_COMMENT: (talkPickId: Id, commentId: Id) =>
+    `talks/${talkPickId}/comments/${commentId}`,
+  DELETE_COMMENT: (talkPickId: Id, commentId: Id) =>
+    `talks/${talkPickId}/comments/${commentId}`,
+  LIKE_COMMENT: (commentId: Id) => `talks/${commentId}/likes`,
+  DELETE_LIKE_COMMENT: (commentId: Id) => `talks/${commentId}/likes`,
+  // REPLILES: (postId: Id, commentId: Id) =>
+  //   `posts/${postId}/comments/${commentId}/replies`,
+  CREATE_REPLY: (commentId: Id) => `talks/comments/${commentId}/replies`,
+  BOOKMARK: (gameId: Id) => `bookmarks/games/${gameId}`,
+  DELETE_BOOKMARK: (gameId: Id) => `bookmarks/games/${gameId}`,
 };
 
 export const AXIOS = {

--- a/src/hooks/api/comment/useBestCommentsQuery.ts
+++ b/src/hooks/api/comment/useBestCommentsQuery.ts
@@ -1,0 +1,17 @@
+import { getBestComments } from '@/api/comments';
+import { Id } from '@/types/api';
+import { CommentsCategory, CommentsPagination } from '@/types/comment';
+import { Pageable } from '@/types/pagination';
+import { useQuery } from '@tanstack/react-query';
+
+export const useBestCommentsQuery = (
+  talkPickId: Id,
+  pageable: Pageable,
+  commentsCategory: Extract<CommentsCategory, 'bestComments'>,
+) => {
+  const { data: bestComments } = useQuery<CommentsPagination>({
+    queryKey: ['talks', talkPickId, commentsCategory, pageable.page],
+    queryFn: () => getBestComments(talkPickId, pageable),
+  });
+  return { bestComments };
+};

--- a/src/hooks/api/comment/useCommentsQuery.ts
+++ b/src/hooks/api/comment/useCommentsQuery.ts
@@ -1,0 +1,17 @@
+import { getComments } from '@/api/comments';
+import { Id } from '@/types/api';
+import { CommentsCategory, CommentsPagination } from '@/types/comment';
+import { Pageable } from '@/types/pagination';
+import { useQuery } from '@tanstack/react-query';
+
+export const useCommentsQuery = (
+  talkPickId: Id,
+  pageable: Pageable,
+  commentsCategory: Extract<CommentsCategory, 'comments'>,
+) => {
+  const { data: comments } = useQuery<CommentsPagination>({
+    queryKey: ['talks', talkPickId, commentsCategory, pageable.page],
+    queryFn: () => getComments(talkPickId, pageable),
+  });
+  return { comments };
+};

--- a/src/hooks/api/comment/useCreateCommentMutation.ts
+++ b/src/hooks/api/comment/useCreateCommentMutation.ts
@@ -1,0 +1,20 @@
+import { postComment } from '@/api/comments';
+import { Id } from '@/types/api';
+import { CommentsCategory, CreateCommentProps } from '@/types/comment';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useCreateCommentMutation = (
+  talkPickId: Id,
+  commentsCategory: CommentsCategory,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (comment: CreateCommentProps) =>
+      postComment(talkPickId, { ...comment }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['talks', talkPickId, commentsCategory],
+      });
+    },
+  });
+};

--- a/src/hooks/api/comment/useCreateCommentMutation.ts
+++ b/src/hooks/api/comment/useCreateCommentMutation.ts
@@ -1,10 +1,12 @@
 import { postComment } from '@/api/comments';
 import { Id } from '@/types/api';
 import { CommentsCategory, CreateCommentProps } from '@/types/comment';
+import { Pageable } from '@/types/pagination';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useCreateCommentMutation = (
   talkPickId: Id,
+  selectedPageNumber: Pick<Pageable, 'page'>,
   commentsCategory: CommentsCategory,
 ) => {
   const queryClient = useQueryClient();
@@ -13,7 +15,7 @@ export const useCreateCommentMutation = (
       postComment(talkPickId, { ...comment }),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['talks', talkPickId, commentsCategory],
+        queryKey: ['talks', talkPickId, commentsCategory, selectedPageNumber],
       });
     },
   });

--- a/src/hooks/api/comment/useCreateReplyMutation.ts
+++ b/src/hooks/api/comment/useCreateReplyMutation.ts
@@ -1,0 +1,22 @@
+import { postReply } from '@/api/comments';
+import { Id } from '@/types/api';
+import { CommentsCategory, CreateReplyProps } from '@/types/comment';
+import { Pageable } from '@/types/pagination';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useCreateReplyMutation = (
+  talkPickId: Id,
+  commentId: Id,
+  selectedPageNumber: Pick<Pageable, 'page'>,
+  commentsCategory: CommentsCategory,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (reply: CreateReplyProps) => postReply(commentId, { ...reply }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['talks', talkPickId, commentsCategory, selectedPageNumber],
+      });
+    },
+  });
+};

--- a/src/hooks/api/comment/useDeleteCommentMutation.ts
+++ b/src/hooks/api/comment/useDeleteCommentMutation.ts
@@ -1,0 +1,20 @@
+import { deleteComment } from '@/api/comments';
+import { Id } from '@/types/api';
+import { CommentsCategory } from '@/types/comment';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useDeleteCommentMutation = (
+  talkPickId: Id,
+  commentId: Id,
+  commentsCategory: CommentsCategory,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => deleteComment(talkPickId, commentId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['talks', talkPickId, commentsCategory],
+      });
+    },
+  });
+};

--- a/src/hooks/api/comment/useDeleteCommentMutation.ts
+++ b/src/hooks/api/comment/useDeleteCommentMutation.ts
@@ -1,11 +1,13 @@
 import { deleteComment } from '@/api/comments';
 import { Id } from '@/types/api';
 import { CommentsCategory } from '@/types/comment';
+import { Pageable } from '@/types/pagination';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useDeleteCommentMutation = (
   talkPickId: Id,
   commentId: Id,
+  selectedPageNumber: Pick<Pageable, 'page'>,
   commentsCategory: CommentsCategory,
 ) => {
   const queryClient = useQueryClient();
@@ -13,7 +15,7 @@ export const useDeleteCommentMutation = (
     mutationFn: () => deleteComment(talkPickId, commentId),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
-        queryKey: ['talks', talkPickId, commentsCategory],
+        queryKey: ['talks', talkPickId, commentsCategory, selectedPageNumber],
       });
     },
   });

--- a/src/hooks/api/comment/useEditCommentMutation.ts
+++ b/src/hooks/api/comment/useEditCommentMutation.ts
@@ -1,0 +1,58 @@
+import { putComment } from '@/api/comments';
+import { Id } from '@/types/api';
+import {
+  Comment,
+  CommentsCategory,
+  CommentsPagination,
+  EditCommentProps,
+} from '@/types/comment';
+import { Pageable } from '@/types/pagination';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useEditCommentMutation = (
+  talkPickId: Id,
+  commentId: Id,
+  selectedPageNumber: Pick<Pageable, 'page'>,
+  commentsCategory: CommentsCategory,
+) => {
+  const queryClient = useQueryClient();
+  const editCommentMutation = useMutation({
+    mutationFn: (comment: EditCommentProps) =>
+      putComment(talkPickId, commentId, { ...comment }),
+    onMutate: (newComment) => {
+      const prevComments: CommentsPagination | undefined =
+        queryClient.getQueryData([
+          'talks',
+          talkPickId,
+          commentsCategory,
+          selectedPageNumber,
+        ]);
+
+      const newComments = prevComments?.content.map((comment: Comment) => {
+        return comment.id === commentId ? { ...comment, newComment } : comment;
+      });
+
+      queryClient.setQueryData(
+        ['talks', talkPickId, commentsCategory, selectedPageNumber],
+        {
+          ...prevComments,
+          content: newComments,
+        },
+      );
+
+      return { prevComments };
+    },
+    onError: (error, id, context) => {
+      queryClient.setQueryData(
+        ['talks', talkPickId, commentsCategory, selectedPageNumber],
+        context?.prevComments,
+      );
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['talks', talkPickId, commentsCategory, selectedPageNumber],
+      });
+    },
+  });
+  return editCommentMutation;
+};

--- a/src/hooks/api/like/useDeleteLikeCommentMutation.ts
+++ b/src/hooks/api/like/useDeleteLikeCommentMutation.ts
@@ -1,0 +1,58 @@
+import { deleteLikeComment } from '@/api/like';
+import { Id } from '@/types/api';
+import { Comment, CommentsCategory, CommentsPagination } from '@/types/comment';
+import { Pageable } from '@/types/pagination';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useDeleteLikeCommentMutation = (
+  talkPickId: Id,
+  commentId: Id,
+  selectedPageNumber: Pick<Pageable, 'page'>,
+  commentsCategory: CommentsCategory,
+) => {
+  const queryClient = useQueryClient();
+  const deleteLikeCommentMutation = useMutation({
+    mutationFn: () => deleteLikeComment(commentId),
+    onMutate: () => {
+      const prevComments: CommentsPagination | undefined =
+        queryClient.getQueryData([
+          'talks',
+          talkPickId,
+          commentsCategory,
+          selectedPageNumber,
+        ]);
+
+      const newComments = prevComments?.content.map((comment: Comment) => {
+        return comment.id === commentId
+          ? {
+              ...comment,
+              myLike: false,
+              likesCount: comment.likesCount - 1,
+            }
+          : comment;
+      });
+
+      queryClient.setQueryData(
+        ['talks', talkPickId, commentsCategory, selectedPageNumber],
+        {
+          ...prevComments,
+          content: newComments,
+        },
+      );
+
+      return { prevComments };
+    },
+    onError: (error, id, context) => {
+      queryClient.setQueryData(
+        ['talks', talkPickId, commentsCategory, selectedPageNumber],
+        context?.prevComments,
+      );
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['talks', talkPickId, commentsCategory, selectedPageNumber],
+      });
+    },
+  });
+  return deleteLikeCommentMutation;
+};

--- a/src/hooks/api/like/useLikeCommentMutation.ts
+++ b/src/hooks/api/like/useLikeCommentMutation.ts
@@ -1,0 +1,58 @@
+import { postLikeComment } from '@/api/like';
+import { Id } from '@/types/api';
+import { Comment, CommentsCategory, CommentsPagination } from '@/types/comment';
+import { Pageable } from '@/types/pagination';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useLikeCommentMutation = (
+  talkPickId: Id,
+  commentId: Id,
+  selectedPageNumber: Pick<Pageable, 'page'>,
+  commentsCategory: CommentsCategory,
+) => {
+  const queryClient = useQueryClient();
+  const likeCommentMutation = useMutation({
+    mutationFn: () => postLikeComment(commentId),
+    onMutate: () => {
+      const prevComments: CommentsPagination | undefined =
+        queryClient.getQueryData([
+          'talks',
+          talkPickId,
+          commentsCategory,
+          selectedPageNumber,
+        ]);
+
+      const newComments = prevComments?.content.map((comment: Comment) => {
+        return comment.id === commentId
+          ? {
+              ...comment,
+              myLike: true,
+              likesCount: comment.likesCount + 1,
+            }
+          : comment;
+      });
+
+      queryClient.setQueryData(
+        ['talks', talkPickId, commentsCategory, selectedPageNumber],
+        {
+          ...prevComments,
+          content: newComments,
+        },
+      );
+
+      return { prevComments };
+    },
+    onError: (error, id, context) => {
+      queryClient.setQueryData(
+        ['talks', talkPickId, commentsCategory, selectedPageNumber],
+        context?.prevComments,
+      );
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['talks', talkPickId, commentsCategory, selectedPageNumber],
+      });
+    },
+  });
+  return likeCommentMutation;
+};

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,2 @@
+export type Id = number;
+export type ServerResponse = string;

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -1,63 +1,41 @@
-export type Comment = {
+import { PaginationType } from './pagination';
+
+export interface Comment {
   id: number;
+  talkPickId: number;
+  talkPickTitle: string;
+  ninckname: string;
   content: string;
-  memberName: string;
-  postId: number;
-  selectedOptionId: number;
-  parentCommentId?: number | null;
+  option: string;
+  likesCount: number;
+  myLike: boolean;
+  replyCount: number;
+  createdAt: string;
+  lastModifiedAt: string;
+}
+
+export interface Reply {
+  id: number;
+  talkPickId: number;
+  ninckname: string;
+  content: string;
+  option: string;
   likesCount: number;
   myLike: boolean;
   createdAt: string;
   lastModifiedAt: string;
-  profileImageUrl: string | null;
-  postTitle?: string;
-  replyCount?: number;
-  writerId: number;
-};
+  parentCommentId: number;
+  isBest: boolean;
+}
 
-export type CreatedComment = Pick<Comment, 'content' | 'selectedOptionId'>;
-export type EditedComment = {
-  content: string;
-  selectedOptionId: number | null;
-};
-export type CreatedReply = {
-  content: string;
-  memberId: number;
-  commentId: number;
-};
-export type CommentsPagination = {
-  totalPages: number;
-  totalElements: number;
-  size: number;
+export interface CommentsPagination extends PaginationType {
   content: Comment[];
-  number: number;
-  sort: {
-    empty: boolean;
-    unsorted: boolean;
-    sorted: boolean;
-  };
-  numberOfElements: number;
-  pageable: {
-    offset: number;
-    sort: {
-      empty: boolean;
-      unsorted: boolean;
-      sorted: boolean;
-    };
-    pageSize: number;
-    paged: boolean;
-    pageNumber: number;
-    unpaged: boolean;
-  };
-  first: boolean;
-  last: boolean;
-  empty: boolean;
-};
+}
 
-export type ReportedComment = {
-  category: string;
-  description: string;
-};
+export type CreateCommentProps = Pick<Comment, 'content' | 'option'>;
 
-// 추후 수정
-export type Replies = Comment[];
+export type EditCommentProps = Pick<Comment, 'content'>;
+
+export type CreateReplyProps = Pick<Comment, 'content' | 'option'>;
+
+export type CommentsCategory = 'comments' | 'bestComments';

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,3 +1,9 @@
+export type Pageable = {
+  page: number;
+  size: number;
+  sort: string[];
+};
+
 export interface PaginationType {
   pageable: {
     pageNumber: number;

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,7 +1,7 @@
 export type Pageable = {
   page: number;
-  size: number;
-  sort: string[];
+  size?: number;
+  sort?: string[];
 };
 
 export interface PaginationType {


### PR DESCRIPTION
## 💡 작업 내용

- [x] comment api endpoint 수정
- [x] comment api 관련 type 정리
- [x] comment, like api 함수 작성
- [x] comment, like api react query 작성

## 💡 자세한 설명

### ✅ comment api 관련 endpoint, type, api 함수 정리

현재 배포되어 있는 스웨거 기준 + 노션에서 받은 답변(프론트엔드 회의록에 기록되어 있음)을 반영하여 comment 관련 api 함수들을 정리했습니다.

- 아직 답글(Reply)의 Type 이 현재 스웨거에 나와있지 않아 이전에 수정되기 전 스웨거에 정의되어있던 답글 Type으로 정의해두었습니다.
- 댓글 좋아요 관련 기능은 현재 스웨거에 like 라는 카테고리로 분류되어 있어 이와 동일하게 like 라는 폴더에 정리해두었습니다.

### ✅ comment react query hook 작성

이전에 작성되어 있던 comment 관련 react query 코드들을 토대로 현재 변경된 사항에 맞게 수정하고, hook으로 분리했습니다.

댓글 종류(최신 댓글 순, 베스트 댓글 순)에 따라 get 해오는 api가 달라 아래의 코드와 같이 구현했습니다.
 베스트 댓글 내역은 bestComments로 타입을 강제해서 쿼리 키에 저장하고,
최신 댓글 내역은 comments로 타입을 강제해서 퀴리 키에 저장했습니다.

```javascript
export const useBestCommentsQuery = (
  talkPickId: Id,
  pageable: Pageable,
  commentsCategory: Extract<CommentsCategory, 'bestComments'>,
) => {
  const { data: bestComments } = useQuery<CommentsPagination>({
    queryKey: ['talks', talkPickId, commentsCategory, pageable.page],
    ...
};

export const useCommentsQuery = (
  talkPickId: Id,
  pageable: Pageable,
  commentsCategory: Extract<CommentsCategory, 'comments'>,
) => {
  const { data: comments } = useQuery<CommentsPagination>({
    queryKey: ['talks', talkPickId, commentsCategory, pageable.page],
    ...
};
```

댓글 등록, 수정, 삭제가 성공하면 댓글 내역을 다시 갱신해야 하는 데, 베스트 댓글 내역을 갱신해야 할 지, 최신 댓글 내역을 갱신해야 할 지 알기 위해 아래와 같이 query 함수 props로 댓글 카테고리 타입을 받게끔 했습니다.

```javascript
export const useDeleteCommentMutation = (
  talkPickId: Id,
  commentId: Id,
  commentsCategory: CommentsCategory,
) => {
    ...
    onSuccess: async () => {
      await queryClient.invalidateQueries({
        queryKey: ['talks', talkPickId, commentsCategory],
      });
    },
  });
};
```

🔎참고
- useEditCommentMutation, useLikeCommentMutation, useDeleteLikeCommentMutation hook들은 낙관적 업데이트를 적용시킨  hook들입니다.
- queryKey 같은 경우에는 댓글 플로우에 따라 변경될 수 있을 것 같습니다. 예를 들어, 자신이 작성한 댓글들은 베스트 순이든, 최신 순이든지 간에 모든 댓글 페이지에 대해서 항상 최상단에 위치하게 할 건 지와 같은 플로우에 따라 달라질 수 있을 것 같아요!

## 📗 참고 자료 (선택)
[낙관적 업데이트](https://tecoble.techcourse.co.kr/post/2023-08-15-how-to-improve-ux-with-optimistic-update/)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #129 
