### PR TITLE
feat: 로딩 중 스켈레톤 UI 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { PATH } from './constants/path';
 import { useMemberQuery } from './hooks/api/member/useMemberQuery';
 import { useParseJwt } from './hooks/common/useParseJwt';
 import { useTokenRefresh } from './hooks/common/useTokenRefresh';
-import { Layout, LayoutMypage, LayoutNoSearch } from './layout/layout';
+import { Layout, LayoutNoFooter } from './layout/layout';
 import CreatePostPage from './pages/CreatePostPage/CreatePostPage';
 // import FindPasswordPage from './pages/FindPasswordPage/FindPasswordPage';
 import LandingPage from './pages/LandingPage/LandingPage';
@@ -58,7 +58,7 @@ const App: React.FC = () => {
             <Route path="post/create" element={<CreatePostPage />} />
           </Route> */}
         </Route>
-        <Route path="/mypage" element={<LayoutMypage />}>
+        <Route path="/mypage" element={<LayoutNoFooter />}>
           <Route index element={<MyPage />} />
         </Route>
         {/* <Route element={<NotAuthRoutes member={member} />}>

--- a/src/components/atoms/MypageCardSkeleton/MypageCardSkeleton.style.ts
+++ b/src/components/atoms/MypageCardSkeleton/MypageCardSkeleton.style.ts
@@ -1,0 +1,24 @@
+import { css } from '@emotion/react';
+import color from '@/styles/color';
+
+export const dateWrapper = css({
+  width: '88px',
+  height: '17px',
+  borderRadius: '20px',
+  backgroundColor: color.GY[3],
+  marginBottom: '9px',
+});
+
+export const cardWrapper = css({
+  width: '432px',
+  height: '354px',
+  borderRadius: '15px',
+  backgroundColor: color.GY[3],
+  marginBottom: '20px',
+});
+
+export const cardContainer = css({
+  display: 'flex',
+  flexDirection: 'row',
+  gap: '20px',
+});

--- a/src/components/atoms/MypageCardSkeleton/MypageCardSkeleton.tsx
+++ b/src/components/atoms/MypageCardSkeleton/MypageCardSkeleton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import * as S from './MypageCardSkeleton.style';
+
+const MypageCardSkeleton = () => {
+  return (
+    <div>
+      <div css={S.dateWrapper} />
+      <div css={S.cardContainer}>
+        <div css={S.cardWrapper} />
+        <div css={S.cardWrapper} />
+      </div>
+      <div css={S.cardWrapper} />
+      <div css={S.dateWrapper} />
+      <div css={S.cardWrapper} />
+    </div>
+  );
+};
+
+export default MypageCardSkeleton;

--- a/src/components/atoms/MypageListSkeleton/MypageListSkeleton.style.ts
+++ b/src/components/atoms/MypageListSkeleton/MypageListSkeleton.style.ts
@@ -1,0 +1,15 @@
+import { css } from '@emotion/react';
+import color from '@/styles/color';
+
+export const listWrapper = css({
+  width: '904px',
+  height: '84px',
+  borderRadius: '20px',
+  backgroundColor: color.GY[3],
+  marginBottom: '10px',
+});
+
+export const listContainer = css({
+  display: 'flex',
+  flexDirection: 'column',
+});

--- a/src/components/atoms/MypageListSkeleton/MypageListSkeleton.tsx
+++ b/src/components/atoms/MypageListSkeleton/MypageListSkeleton.tsx
@@ -1,0 +1,15 @@
+/* eslint-disable react/no-array-index-key */
+import React from 'react';
+import * as S from './MypageListSkeleton.style';
+
+const MypageListSkeleton = () => {
+  return (
+    <div css={S.listContainer}>
+      {Array.from({ length: 8 }).map((_, index) => (
+        <div key={index} css={S.listWrapper} />
+      ))}
+    </div>
+  );
+};
+
+export default MypageListSkeleton;

--- a/src/components/atoms/MypageListSkeleton/MypageListSkeleton.tsx
+++ b/src/components/atoms/MypageListSkeleton/MypageListSkeleton.tsx
@@ -2,10 +2,14 @@
 import React from 'react';
 import * as S from './MypageListSkeleton.style';
 
-const MypageListSkeleton = () => {
+interface MypageListSkeletonProps {
+  count: number;
+}
+
+const MypageListSkeleton = ({ count = 8 }: MypageListSkeletonProps) => {
   return (
     <div css={S.listContainer}>
-      {Array.from({ length: 8 }).map((_, index) => (
+      {Array.from({ length: count }).map((_, index) => (
         <div key={index} css={S.listWrapper} />
       ))}
     </div>

--- a/src/components/atoms/ProfileIcon/ProfileIcon.tsx
+++ b/src/components/atoms/ProfileIcon/ProfileIcon.tsx
@@ -3,7 +3,7 @@ import { NormalProfile } from '@/assets';
 import { profileWrapper, profileImage } from './ProfileIcon.style';
 
 export interface ProfileProps extends ComponentPropsWithRef<'button'> {
-  interaction: 'normal' | 'settings';
+  interaction: 'default' | 'custom';
   imgUrl?: string;
   size?: 'small' | 'large';
 }
@@ -16,7 +16,7 @@ interface ProfilePropsWithImage extends ComponentPropsWithRef<'button'> {
 
 const ProfileIcon = (
   {
-    interaction = 'normal',
+    interaction = 'default',
     imgUrl,
     size = 'small',
     ...props

--- a/src/components/atoms/ProfileIcon/ProfileIcon.tsx
+++ b/src/components/atoms/ProfileIcon/ProfileIcon.tsx
@@ -2,8 +2,8 @@ import React, { ComponentPropsWithRef, ForwardedRef, forwardRef } from 'react';
 import { NormalProfile } from '@/assets';
 import { profileWrapper, profileImage } from './ProfileIcon.style';
 
-interface ProfileProps extends ComponentPropsWithRef<'button'> {
-  interaction: 'normal';
+export interface ProfileProps extends ComponentPropsWithRef<'button'> {
+  interaction: 'normal' | 'settings';
   imgUrl?: string;
   size?: 'small' | 'large';
 }

--- a/src/components/atoms/SearchResultCardSkeleton/SearchResultCardSkeleton.style.ts
+++ b/src/components/atoms/SearchResultCardSkeleton/SearchResultCardSkeleton.style.ts
@@ -1,0 +1,17 @@
+import { css } from '@emotion/react';
+import color from '@/styles/color';
+
+export const gridContainer = css({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  gap: '20px',
+});
+
+export const cardWrapper = css({
+  width: '369px',
+  height: '278px',
+  borderRadius: '10px',
+  backgroundColor: color.GY[3],
+});
+
+export const rowContainer = css({});

--- a/src/components/atoms/SearchResultCardSkeleton/SearchResultCardSkeleton.tsx
+++ b/src/components/atoms/SearchResultCardSkeleton/SearchResultCardSkeleton.tsx
@@ -1,0 +1,15 @@
+/* eslint-disable react/no-array-index-key */
+import React from 'react';
+import * as S from './SearchResultCardSkeleton.style';
+
+const SearchResultCardSkeleton = () => {
+  return (
+    <div css={S.gridContainer}>
+      {Array.from({ length: 9 }).map((_, index) => (
+        <div key={index} css={S.cardWrapper} />
+      ))}
+    </div>
+  );
+};
+
+export default SearchResultCardSkeleton;

--- a/src/components/atoms/SearchResultCardSkeleton/SearchResultCardSkeleton.tsx
+++ b/src/components/atoms/SearchResultCardSkeleton/SearchResultCardSkeleton.tsx
@@ -2,10 +2,16 @@
 import React from 'react';
 import * as S from './SearchResultCardSkeleton.style';
 
-const SearchResultCardSkeleton = () => {
+interface SearchResultCardSkeletonProps {
+  count: number;
+}
+
+const SearchResultCardSkeleton = ({
+  count = 9,
+}: SearchResultCardSkeletonProps) => {
   return (
     <div css={S.gridContainer}>
-      {Array.from({ length: 9 }).map((_, index) => (
+      {Array.from({ length: count }).map((_, index) => (
         <div key={index} css={S.cardWrapper} />
       ))}
     </div>

--- a/src/components/atoms/SearchResultListSkeleton/SearchResultListSkeleton.style.ts
+++ b/src/components/atoms/SearchResultListSkeleton/SearchResultListSkeleton.style.ts
@@ -1,0 +1,42 @@
+import { css } from '@emotion/react';
+import color from '@/styles/color';
+
+export const listContainer = css({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const contentContainer = css({
+  display: 'flex',
+  flexDirection: 'row',
+  margin: '10px 0',
+  alignItems: 'center',
+});
+
+export const leftContainer = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '9px',
+  marginRight: '104px',
+});
+
+export const topWrapper = css({
+  width: '397px',
+  height: '30px',
+  borderRadius: '10px',
+  backgroundColor: color.GY[3],
+});
+
+export const bottomWrapper = css({
+  width: '862px',
+  height: '46px',
+  borderRadius: '15px',
+  backgroundColor: color.GY[3],
+});
+
+export const imageWrapper = css({
+  width: '100px',
+  height: '100px',
+  borderRadius: '10px',
+  backgroundColor: color.GY[3],
+});

--- a/src/components/atoms/SearchResultListSkeleton/SearchResultListSkeleton.tsx
+++ b/src/components/atoms/SearchResultListSkeleton/SearchResultListSkeleton.tsx
@@ -1,0 +1,25 @@
+/* eslint-disable react/no-array-index-key */
+import React from 'react';
+import Divider from '@/components/atoms/Divider/Divider';
+import * as S from './SearchResultListSkeleton.style';
+
+const SearchResultListSkeleton = () => {
+  return (
+    <div css={S.listContainer}>
+      {Array.from({ length: 10 }).map((_, index) => (
+        <React.Fragment key={index}>
+          <div css={S.contentContainer}>
+            <div css={S.leftContainer}>
+              <div css={S.topWrapper} />
+              <div css={S.bottomWrapper} />
+            </div>
+            <div css={S.imageWrapper} />
+          </div>
+          {index < 9 && <Divider orientation="width" length={1065} />}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+};
+
+export default SearchResultListSkeleton;

--- a/src/components/atoms/SearchResultListSkeleton/SearchResultListSkeleton.tsx
+++ b/src/components/atoms/SearchResultListSkeleton/SearchResultListSkeleton.tsx
@@ -3,10 +3,16 @@ import React from 'react';
 import Divider from '@/components/atoms/Divider/Divider';
 import * as S from './SearchResultListSkeleton.style';
 
-const SearchResultListSkeleton = () => {
+interface SearchResultListSkeletonProps {
+  length: number;
+}
+
+const SearchResultListSkeleton = ({
+  length,
+}: SearchResultListSkeletonProps) => {
   return (
     <div css={S.listContainer}>
-      {Array.from({ length: 10 }).map((_, index) => (
+      {Array.from({ length }).map((_, index) => (
         <React.Fragment key={index}>
           <div css={S.contentContainer}>
             <div css={S.leftContainer}>
@@ -15,7 +21,7 @@ const SearchResultListSkeleton = () => {
             </div>
             <div css={S.imageWrapper} />
           </div>
-          {index < 9 && <Divider orientation="width" length={1065} />}
+          {index < length - 1 && <Divider orientation="width" length={1065} />}
         </React.Fragment>
       ))}
     </div>

--- a/src/components/organisms/SideBar/SideBar.style.ts
+++ b/src/components/organisms/SideBar/SideBar.style.ts
@@ -1,19 +1,20 @@
 import { css } from '@emotion/react';
 import color from '@/styles/color';
 
-export const sidebarContainer = css({
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-  backgroundColor: color.WT,
-  borderRadius: '20px',
-  width: '258px',
-  height: '538px',
-  flexShrink: 0,
-  border: `1px solid ${color.SKYBLUE}`,
-  paddingTop: '30px',
-  paddingBottom: '35px',
-});
+export const sidebarContainer = (isLoading: boolean) =>
+  css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    backgroundColor: isLoading ? color.GY[3] : color.WT,
+    borderRadius: '20px',
+    width: '258px',
+    height: '538px',
+    flexShrink: 0,
+    border: isLoading ? '' : `1px solid ${color.SKYBLUE}`,
+    paddingTop: '30px',
+    paddingBottom: '35px',
+  });
 
 export const profileWrapper = css({
   display: 'flex',

--- a/src/components/organisms/SideBar/SideBar.style.ts
+++ b/src/components/organisms/SideBar/SideBar.style.ts
@@ -20,7 +20,6 @@ export const profileWrapper = css({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  marginBottom: '40px',
   width: '100%',
 });
 
@@ -35,4 +34,5 @@ export const profileLabelBox = css({
 
 export const sideWrapper = css({
   width: '100%',
+  marginBottom: '40px',
 });

--- a/src/components/organisms/SideBar/SideBar.tsx
+++ b/src/components/organisms/SideBar/SideBar.tsx
@@ -24,7 +24,7 @@ const SideBar = ({
   bookmarkedPostsCount,
   isLoading = false,
 }: SideBarProps) => {
-  const profileIconInteraction = profileImageUrl ? 'settings' : 'normal';
+  const profileIconInteraction = profileImageUrl ? 'custom' : 'default';
 
   return (
     <div css={S.sidebarContainer(isLoading)}>

--- a/src/components/organisms/SideBar/SideBar.tsx
+++ b/src/components/organisms/SideBar/SideBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ProfileIcon, {
-  ProfileIconProps,
+  ProfileProps,
 } from '@/components/atoms/ProfileIcon/ProfileIcon';
 import ProfileLabel, {
   ProfileLabelProps,
@@ -10,10 +10,11 @@ import ActionBox from '@/components/molecules/ActionBox/ActionBox';
 import * as S from './SideBar.style';
 
 export interface SideBarProps {
-  nickname: ProfileLabelProps['nickname'];
-  postsCount: SideBoxProps['postsCount'];
-  bookmarkedPostsCount: SideBoxProps['bookmarkedPostsCount'];
-  profileImageUrl?: ProfileIconProps['imgUrl'];
+  nickname?: ProfileLabelProps['nickname'];
+  postsCount?: SideBoxProps['postsCount'];
+  bookmarkedPostsCount?: SideBoxProps['bookmarkedPostsCount'];
+  profileImageUrl?: ProfileProps['imgUrl'];
+  isLoading?: boolean;
 }
 
 const SideBar = ({
@@ -21,30 +22,35 @@ const SideBar = ({
   profileImageUrl,
   postsCount,
   bookmarkedPostsCount,
+  isLoading = false,
 }: SideBarProps) => {
   const profileIconInteraction = profileImageUrl ? 'settings' : 'normal';
 
   return (
-    <div css={S.sidebarContainer}>
-      <div css={S.profileWrapper}>
-        <ProfileIcon
-          interaction={profileIconInteraction}
-          imgUrl={profileImageUrl}
-          size="large"
-        />
-        <div css={S.profileLabelBox}>
-          <ProfileLabel nickname={nickname} />
-        </div>
-        <div css={S.sideWrapper}>
-          <SideBox
-            postsCount={postsCount}
-            bookmarkedPostsCount={bookmarkedPostsCount}
+    <div css={S.sidebarContainer(isLoading)}>
+      {isLoading ? (
+        <div />
+      ) : (
+        <div css={S.profileWrapper}>
+          <ProfileIcon
+            interaction={profileIconInteraction}
+            imgUrl={profileImageUrl}
+            size="large"
           />
+          <div css={S.profileLabelBox}>
+            <ProfileLabel nickname={nickname} />
+          </div>
+          <div css={S.sideWrapper}>
+            <SideBox
+              postsCount={postsCount}
+              bookmarkedPostsCount={bookmarkedPostsCount}
+            />
+          </div>
+          <div css={S.actionWrapper}>
+            <ActionBox />
+          </div>
         </div>
-      </div>
-      <div css={S.actionWrapper}>
-        <ActionBox />
-      </div>
+      )}
     </div>
   );
 };

--- a/src/hooks/api/mypages/useGameBookmarksQuery.ts
+++ b/src/hooks/api/mypages/useGameBookmarksQuery.ts
@@ -9,6 +9,7 @@ export const useGameBookmarksQuery = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading,
   } = useInfiniteScroll<GameBookmark>(
     ['gameBookmark'],
     ({ pageParam = 0 }) => getGameBookmark(pageParam, 20),
@@ -40,5 +41,6 @@ export const useGameBookmarksQuery = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading,
   };
 };

--- a/src/hooks/api/mypages/useGameVotesQuery.ts
+++ b/src/hooks/api/mypages/useGameVotesQuery.ts
@@ -9,6 +9,7 @@ export const useGameVotesQuery = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading,
   } = useInfiniteScroll<GameVote>(
     ['gameVote'],
     ({ pageParam = 0 }) => getGameVote(pageParam, 20),
@@ -40,5 +41,6 @@ export const useGameVotesQuery = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading,
   };
 };

--- a/src/hooks/api/mypages/useGameWrittensQuery.ts
+++ b/src/hooks/api/mypages/useGameWrittensQuery.ts
@@ -9,6 +9,7 @@ export const useGameWrittensQuery = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading,
   } = useInfiniteScroll<GameWritten>(
     ['gameWritten'],
     ({ pageParam = 0 }) => getGameWritten(pageParam, 20),
@@ -40,5 +41,6 @@ export const useGameWrittensQuery = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading,
   };
 };

--- a/src/hooks/api/mypages/useInfiniteScroll.ts
+++ b/src/hooks/api/mypages/useInfiniteScroll.ts
@@ -5,7 +5,7 @@ export const useInfiniteScroll = <T extends { last: boolean; number: number }>(
   queryFn: ({ pageParam }: { pageParam?: number }) => Promise<T>,
   selectFn: (data: InfiniteData<T>) => T,
 ) => {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
     useInfiniteQuery<T, Error, T, typeof queryKey, number>({
       queryKey,
       queryFn,
@@ -16,5 +16,5 @@ export const useInfiniteScroll = <T extends { last: boolean; number: number }>(
       select: selectFn,
     });
 
-  return { data, fetchNextPage, hasNextPage, isFetchingNextPage };
+  return { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading };
 };

--- a/src/hooks/api/mypages/useMyBookmarksQuery.ts
+++ b/src/hooks/api/mypages/useMyBookmarksQuery.ts
@@ -9,6 +9,7 @@ export const useMyBookmarksQuery = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading,
   } = useInfiniteScroll<MyBookmark>(
     ['myBookmarks'],
     ({ pageParam = 0 }) => getMyBookmark(pageParam, 20),
@@ -40,5 +41,6 @@ export const useMyBookmarksQuery = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading,
   };
 };

--- a/src/hooks/api/mypages/useMyCommentsQuery.ts
+++ b/src/hooks/api/mypages/useMyCommentsQuery.ts
@@ -9,6 +9,7 @@ export const useMyCommentsQuery = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading,
   } = useInfiniteScroll<MyComment>(
     ['myComments'],
     ({ pageParam = 0 }) => getMyComment(pageParam, 20),
@@ -40,5 +41,6 @@ export const useMyCommentsQuery = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading,
   };
 };

--- a/src/hooks/api/mypages/useMyInfoQuery.ts
+++ b/src/hooks/api/mypages/useMyInfoQuery.ts
@@ -4,11 +4,11 @@ import { SideBar } from '@/types/mypages';
 import { Id } from '@/types/api';
 
 export const useMyInfoQuery = (memberId: Id) => {
-  const { data: memberInfo } = useQuery<SideBar>({
+  const { data: memberInfo, isLoading } = useQuery<SideBar>({
     queryKey: ['memberInfo', memberId],
     queryFn: () => getMyInfo(memberId),
     enabled: !!memberId,
   });
 
-  return { memberInfo };
+  return { memberInfo, isLoading };
 };

--- a/src/hooks/api/mypages/useMyVotesQuery.ts
+++ b/src/hooks/api/mypages/useMyVotesQuery.ts
@@ -9,6 +9,7 @@ export const useMyVotesQuery = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading,
   } = useInfiniteScroll<MyVote>(
     ['myVote'],
     ({ pageParam = 0 }) => getMyVote(pageParam, 20),
@@ -39,5 +40,6 @@ export const useMyVotesQuery = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading,
   };
 };

--- a/src/hooks/api/mypages/useMyWrittensQuery.ts
+++ b/src/hooks/api/mypages/useMyWrittensQuery.ts
@@ -9,6 +9,7 @@ export const useMyWrittensQuery = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading,
   } = useInfiniteScroll<MyWritten>(
     ['myWritten'],
     ({ pageParam = 0 }) => getMyWritten(pageParam, 20),
@@ -40,5 +41,6 @@ export const useMyWrittensQuery = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    isLoading,
   };
 };

--- a/src/layout/layout.tsx
+++ b/src/layout/layout.tsx
@@ -41,7 +41,7 @@ export const LayoutNoSearch = () => {
   );
 };
 
-export const LayoutMypage = () => {
+export const LayoutNoFooter = () => {
   return (
     <>
       <Header />

--- a/src/pages/MyPage/MyPage.style.ts
+++ b/src/pages/MyPage/MyPage.style.ts
@@ -8,6 +8,7 @@ export const pageContainer = css`
   padding: 60px 362px 0 361px;
   background-color: ${color.WT}
   overflow: hidden;
+  margin-top: 100px;
 `;
 
 export const contentWrapper = css`

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -50,7 +50,7 @@ const MyPage = () => {
     gameWrittens: useGameWrittensQuery(),
   };
 
-  const queryisLoading = Object.values(queries).some(
+  const isQueryLoading = Object.values(queries).some(
     (query) => query.isLoading,
   );
 

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -105,7 +105,7 @@ const MyPage = () => {
   ]);
 
   const renderContent = () => {
-    if (queryisLoading) {
+    if (isQueryLoading) {
       const skeletonCount = queryResult?.content?.length || 8;
       if (selectedGroup === OptionKeys.TALK_PICK) {
         return <MypageListSkeleton count={skeletonCount} />;

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -22,6 +22,8 @@ import { useNewSelector } from '@/store';
 import { selectAccessToken } from '@/store/auth';
 import { useMemberQuery } from '@/hooks/api/member/useMemberQuery';
 import { useParseJwt } from '@/hooks/common/useParseJwt';
+import MypageListSkeleton from '@/components/atoms/MypageListSkeleton/MypageListSkeleton';
+import MypageCardSkeleton from '@/components/atoms/MypageCardSkeleton/MypageCardSkeleton';
 import * as S from './MyPage.style';
 
 const MyPage = () => {
@@ -29,7 +31,7 @@ const MyPage = () => {
   const { member } = useMemberQuery(useParseJwt(accessToken).memberId);
   const memberId: number = member!.id;
 
-  const { memberInfo } = useMyInfoQuery(memberId);
+  const { memberInfo, isLoading } = useMyInfoQuery(memberId);
   const myBookmarksQuery = useMyBookmarksQuery();
   const myVotesQuery = useMyVotesQuery();
   const myCommentsQuery = useMyCommentsQuery();
@@ -47,6 +49,10 @@ const MyPage = () => {
     gameVotes: useGameVotesQuery(),
     gameWrittens: useGameWrittensQuery(),
   };
+
+  const queryisLoading = Object.values(queries).some(
+    (query) => query.isLoading,
+  );
 
   const { ref, isFetchingAnyNextPage } = useObserver(queries);
 
@@ -99,6 +105,15 @@ const MyPage = () => {
   ]);
 
   const renderContent = () => {
+    if (queryisLoading) {
+      if (selectedGroup === OptionKeys.TALK_PICK) {
+        return <MypageListSkeleton />;
+      }
+      if (selectedGroup === OptionKeys.BALANCE_GAME) {
+        return <MypageCardSkeleton />;
+      }
+    }
+
     if (!queryResult) {
       return <div>표시할 페이지가 없습니다</div>;
     }
@@ -128,13 +143,17 @@ const MyPage = () => {
 
   return (
     <div css={S.pageContainer}>
-      {memberInfo && (
-        <SideBar
-          nickname={memberInfo.nickname}
-          profileImageUrl={memberInfo.profileImageUrl}
-          postsCount={memberInfo.postsCount}
-          bookmarkedPostsCount={memberInfo.bookmarkedPostsCount}
-        />
+      {isLoading ? (
+        <SideBar isLoading />
+      ) : (
+        memberInfo && (
+          <SideBar
+            nickname={memberInfo.nickname}
+            profileImageUrl={memberInfo.profileImageUrl}
+            postsCount={memberInfo.postsCount}
+            bookmarkedPostsCount={memberInfo.bookmarkedPostsCount}
+          />
+        )
       )}
       <div css={S.contentWrapper}>
         <OptionBar

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -41,13 +41,13 @@ const MyPage = () => {
   const gameWrittensQuery = useGameWrittensQuery();
 
   const queries = {
-    myBookmarks: useMyBookmarksQuery(),
-    myVotes: useMyVotesQuery(),
-    myComments: useMyCommentsQuery(),
-    myWrittens: useMyWrittensQuery(),
-    gameBookmarks: useGameBookmarksQuery(),
-    gameVotes: useGameVotesQuery(),
-    gameWrittens: useGameWrittensQuery(),
+    myBookmarks: myBookmarksQuery,
+    myVotes: myVotesQuery,
+    myComments: myCommentsQuery,
+    myWrittens: myWrittensQuery,
+    gameBookmarks: gameBookmarksQuery,
+    gameVotes: gameVotesQuery,
+    gameWrittens: gameWrittensQuery,
   };
 
   const isQueryLoading = Object.values(queries).some(
@@ -106,8 +106,9 @@ const MyPage = () => {
 
   const renderContent = () => {
     if (queryisLoading) {
+      const skeletonCount = queryResult?.content?.length || 8;
       if (selectedGroup === OptionKeys.TALK_PICK) {
-        return <MypageListSkeleton />;
+        return <MypageListSkeleton count={skeletonCount} />;
       }
       if (selectedGroup === OptionKeys.BALANCE_GAME) {
         return <MypageCardSkeleton />;

--- a/src/stories/atoms/MypageCardSkeleton.stories.tsx
+++ b/src/stories/atoms/MypageCardSkeleton.stories.tsx
@@ -5,7 +5,6 @@ const meta = {
   title: 'atoms/MypageCardSkeleton',
   component: MypageCardSkeleton,
   parameters: {},
-  tags: ['autodocs'],
 } satisfies Meta<typeof MypageCardSkeleton>;
 
 export default meta;

--- a/src/stories/atoms/MypageCardSkeleton.stories.tsx
+++ b/src/stories/atoms/MypageCardSkeleton.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import MypageCardSkeleton from '@/components/atoms/MypageCardSkeleton/MypageCardSkeleton';
+
+const meta = {
+  title: 'atoms/MypageCardSkeleton',
+  component: MypageCardSkeleton,
+  parameters: {},
+  tags: ['autodocs'],
+} satisfies Meta<typeof MypageCardSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/atoms/MypageListSkeleton.stories.tsx
+++ b/src/stories/atoms/MypageListSkeleton.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import MypageListSkeleton from '@/components/atoms/MypageListSkeleton/MypageListSkeleton';
+
+const meta = {
+  title: 'atoms/MypageListSkeleton',
+  component: MypageListSkeleton,
+  parameters: {},
+  tags: ['autodocs'],
+} satisfies Meta<typeof MypageListSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/atoms/MypageListSkeleton.stories.tsx
+++ b/src/stories/atoms/MypageListSkeleton.stories.tsx
@@ -5,7 +5,6 @@ const meta = {
   title: 'atoms/MypageListSkeleton',
   component: MypageListSkeleton,
   parameters: {},
-  tags: ['autodocs'],
 } satisfies Meta<typeof MypageListSkeleton>;
 
 export default meta;

--- a/src/stories/atoms/MypageListSkeleton.stories.tsx
+++ b/src/stories/atoms/MypageListSkeleton.stories.tsx
@@ -5,9 +5,18 @@ const meta = {
   title: 'atoms/MypageListSkeleton',
   component: MypageListSkeleton,
   parameters: {},
+  argTypes: {
+    count: {
+      control: { type: 'number' },
+    },
+  },
 } satisfies Meta<typeof MypageListSkeleton>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    count: 8,
+  },
+};

--- a/src/stories/atoms/SearchResultCardSkeleton.stories.tsx
+++ b/src/stories/atoms/SearchResultCardSkeleton.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SearchResultCardSkeleton from '@/components/atoms/SearchResultCardSkeleton/SearchResultCardSkeleton';
+
+const meta = {
+  title: 'atoms/SearchResultCardSkeleton',
+  component: SearchResultCardSkeleton,
+  parameters: {},
+  tags: ['autodocs'],
+} satisfies Meta<typeof SearchResultCardSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/atoms/SearchResultCardSkeleton.stories.tsx
+++ b/src/stories/atoms/SearchResultCardSkeleton.stories.tsx
@@ -5,9 +5,18 @@ const meta = {
   title: 'atoms/SearchResultCardSkeleton',
   component: SearchResultCardSkeleton,
   parameters: {},
+  argTypes: {
+    count: {
+      control: { type: 'number' },
+    },
+  },
 } satisfies Meta<typeof SearchResultCardSkeleton>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    count: 9,
+  },
+};

--- a/src/stories/atoms/SearchResultCardSkeleton.stories.tsx
+++ b/src/stories/atoms/SearchResultCardSkeleton.stories.tsx
@@ -5,7 +5,6 @@ const meta = {
   title: 'atoms/SearchResultCardSkeleton',
   component: SearchResultCardSkeleton,
   parameters: {},
-  tags: ['autodocs'],
 } satisfies Meta<typeof SearchResultCardSkeleton>;
 
 export default meta;

--- a/src/stories/atoms/SearchResultListSkeleton.stories.tsx
+++ b/src/stories/atoms/SearchResultListSkeleton.stories.tsx
@@ -5,7 +5,6 @@ const meta = {
   title: 'atoms/SearchResultListSkeleton',
   component: SearchResultListSkeleton,
   parameters: {},
-  tags: ['autodocs'],
   argTypes: {
     length: {
       control: { type: 'number' },

--- a/src/stories/atoms/SearchResultListSkeleton.stories.tsx
+++ b/src/stories/atoms/SearchResultListSkeleton.stories.tsx
@@ -6,9 +6,18 @@ const meta = {
   component: SearchResultListSkeleton,
   parameters: {},
   tags: ['autodocs'],
+  argTypes: {
+    length: {
+      control: { type: 'number' },
+    },
+  },
 } satisfies Meta<typeof SearchResultListSkeleton>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    length: 10,
+  },
+};

--- a/src/stories/atoms/SearchResultListSkeleton.stories.tsx
+++ b/src/stories/atoms/SearchResultListSkeleton.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SearchResultListSkeleton from '@/components/atoms/SearchResultListSkeleton/SearchResultListSkeleton';
+
+const meta = {
+  title: 'atoms/SearchResultListSkeleton',
+  component: SearchResultListSkeleton,
+  parameters: {},
+  tags: ['autodocs'],
+} satisfies Meta<typeof SearchResultListSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/stories/organisms/SideBar.stories.tsx
+++ b/src/stories/organisms/SideBar.stories.tsx
@@ -10,7 +10,6 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     nickname: { control: { type: 'text' }, defaultValue: 'Aycho' },
     profileImageUrl: {
@@ -19,6 +18,7 @@ const meta = {
     },
     postsCount: { control: { type: 'number' }, defaultValue: 23 },
     bookmarkedPostsCount: { control: { type: 'number' }, defaultValue: 21 },
+    isLoading: { control: { type: 'boolean' } },
   },
 } satisfies Meta<typeof SideBar>;
 
@@ -31,6 +31,7 @@ export const Default: Story = {
     profileImageUrl: ProfileInfoSample,
     postsCount: 23,
     bookmarkedPostsCount: 21,
+    isLoading: false,
   },
 };
 
@@ -61,6 +62,17 @@ export const All: Story = {
           bookmarkedPostsCount={15}
         />
       </li>
+      <li css={storyInnerContainer}>
+        <h3>로딩중인 경우</h3>
+        <SideBar
+          {...args}
+          nickname="Aycho"
+          profileImageUrl={ProfileInfoSample}
+          postsCount={45}
+          bookmarkedPostsCount={15}
+          isLoading
+        />
+      </li>
     </ul>
   ),
   args: {
@@ -68,5 +80,6 @@ export const All: Story = {
     profileImageUrl: ProfileInfoSample,
     postsCount: 23,
     bookmarkedPostsCount: 21,
+    isLoading: false,
   },
 };


### PR DESCRIPTION
## 💡 작업 내용

- [x] LayoutMypage 명 수정 및 적용
- [x] `SideBar` Loading 상태에 따른 스켈레톤 스타일 적용
- [x] `MypageCardSkeleton` UI 및 스토리북 구현
- [x] `MypageListSkeleton` UI 및 스토리북 구현
- [x] `SearchResultCardSkeleton` UI 및 스토리북 구현
- [x] `SearchResultListSkeleton` UI 및 스토리북 구현

## 💡 자세한 설명
### ✅ Mypage Skeleton
- `SideBar`는 컴포넌트 분리대신 isLoading값을 props로 받아와서 true일 시에만 style이 변하도록 수정해놓았습니다.
<img width="500px" alt="스크린샷 2024-10-31 오전 1 46 51" src="https://github.com/user-attachments/assets/dc3d1807-d6f6-49dc-9dbd-555414c3a1d7">

- Mypage 스켈레톤 디자인이 총 두가지로, `MypageCardSkeleton`와 `MypageListSkeleton`로 구현해놓았습니다.
- queries 객체의 상태를 확인하여 로딩 상태 및 selectedGroup에 따라 스켈레톤을 보여주도록 구현하였습니다.
```javascript
const queryisLoading = Object.values(queries).some(
    (query) => query.isLoading,
  );
  
if (queryisLoading) {
      if (selectedGroup === OptionKeys.TALK_PICK) {
        return <MypageListSkeleton />;
      }
      if (selectedGroup === OptionKeys.BALANCE_GAME) {
        return <MypageCardSkeleton />;
      }
}
```

### ✅ SearchResultPage Skeleton
- `SearchResultCardSkeleton`는 밸런스게임 검색 결과에 대한 스켈레톤입니다. 태그 상관없이 밸런스게임 검색 결과에 대한 스켈레톤은 동일하기 때문에 따로 props는 없습니다.
- `SearchResultListSkeleton`는 톡픽 검색 결과에 대한 스켈레톤입니다. `전체` 태그와 `톡픽` 태그 검색 결과의 스켈레톤이 달라 props로 리스트 길이 값을 받아오도록 하였습니다.
```javascript
interface SearchResultListSkeletonProps {
  length: number;
}
<SearchResultListSkeleton length={10}/> // 태그가 톡픽일 때
<SearchResultListSkeleton length={4}/> // 태그가 전체일 때

```
- 아직 검색 결과 페이지가 머지되지 않아 UI만 구현된 상태입니다. 추후 머지 시 페이지에 적용필요합니다.
- 모든 스켈레톤 UI는 스토리북에서 확인 가능합니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #203 
