### PR TITLE
feat: 톡픽 비회원 투표 기능 구현

### DIFF
--- a/src/components/molecules/LoginForm/LoginForm.tsx
+++ b/src/components/molecules/LoginForm/LoginForm.tsx
@@ -12,11 +12,12 @@ import * as S from './LoginFrom.style';
 
 export interface LoginFormProps {
   withSignInText?: boolean;
+  pathTalkPickId?: number;
 }
 
-const LoginForm = ({ withSignInText }: LoginFormProps) => {
+const LoginForm = ({ withSignInText, pathTalkPickId }: LoginFormProps) => {
   const { form, onChange, isError, errorMessage, handleSubmit, loginSuccess } =
-    useLoginForm();
+    useLoginForm(pathTalkPickId);
 
   const handleSocialLogin = (social: string) => {
     window.location.href = `${process.env.API_URL}/oauth2/authorization/${social}`;

--- a/src/components/molecules/VotePrototype/VotePrototype.style.ts
+++ b/src/components/molecules/VotePrototype/VotePrototype.style.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { VoteOption, MyVoteOption } from '@/types/vote';
 import typo from '@/styles/typo';
 import color from '@/styles/color';
 
@@ -23,8 +24,8 @@ export const voteTextStyle = css(typo.Component.Bold, {
 });
 
 export const getButtonStyle = (
-  side: 'A' | 'B',
-  selectedButton: 'A' | 'B' | null,
+  side: VoteOption,
+  selectedButton: MyVoteOption,
 ) =>
   css({
     ...(selectedButton === side && {

--- a/src/components/molecules/VotePrototype/VotePrototype.style.ts
+++ b/src/components/molecules/VotePrototype/VotePrototype.style.ts
@@ -24,7 +24,7 @@ export const voteTextStyle = css(typo.Component.Bold, {
 
 export const getButtonStyle = (
   side: 'A' | 'B',
-  selectedButton: string | null,
+  selectedButton: 'A' | 'B' | null,
 ) =>
   css({
     ...(selectedButton === side && {

--- a/src/components/molecules/VotePrototype/VotePrototype.style.ts
+++ b/src/components/molecules/VotePrototype/VotePrototype.style.ts
@@ -7,6 +7,8 @@ export const votePrototypeStyle = css({
   flexDirection: 'column',
   alignItems: 'center',
   gap: '20px',
+  position: 'relative',
+  overflow: 'visible',
 });
 
 export const buttonContainerStyle = css({
@@ -22,7 +24,7 @@ export const voteTextStyle = css(typo.Component.Bold, {
 
 export const getButtonStyle = (
   side: 'A' | 'B',
-  selectedButton: 'A' | 'B' | null,
+  selectedButton: string | null,
 ) =>
   css({
     ...(selectedButton === side && {
@@ -31,3 +33,23 @@ export const getButtonStyle = (
       outline: 'none',
     }),
   });
+
+export const loggedOutContainerStyling = css({
+  display: 'flex',
+  position: 'absolute',
+  top: '90px',
+  left: '-100px',
+  width: '1215px',
+  height: '260px',
+  backdropFilter: 'blur(11px)',
+  backgroundColor: 'rgba(255, 255, 255, 0.01)',
+  zIndex: 1,
+});
+
+export const toastModalStyling = css({
+  position: 'fixed',
+  top: '110px',
+  left: '50%',
+  transform: 'translate(-50%)',
+  zIndex: '1000',
+});

--- a/src/components/molecules/VotePrototype/VotePrototype.tsx
+++ b/src/components/molecules/VotePrototype/VotePrototype.tsx
@@ -85,7 +85,7 @@ const VotePrototype: React.FC<VotePrototypeProps> = ({
     }
   };
 
-  const handleVoteButtonClick = (voteOption: 'A' | 'B') => () => {
+  const handleVoteButtonClick = (voteOption: 'A' | 'B') => {
     if (accessToken) {
       handleTalkPickVote(selectedVote, voteOption);
     } else {
@@ -104,7 +104,9 @@ const VotePrototype: React.FC<VotePrototypeProps> = ({
         <Button
           variant="outlineHighlightR"
           size="large"
-          onClick={handleVoteButtonClick('A')}
+          onClick={() => {
+            handleVoteButtonClick('A');
+          }}
           css={S.getButtonStyle(
             'A',
             accessToken ? selectedVote : loggedOutVoteOption,
@@ -116,7 +118,9 @@ const VotePrototype: React.FC<VotePrototypeProps> = ({
         <Button
           variant="outlineHighlightB"
           size="large"
-          onClick={handleVoteButtonClick('B')}
+          onClick={() => {
+            handleVoteButtonClick('B');
+          }}
           css={S.getButtonStyle(
             'B',
             accessToken ? selectedVote : loggedOutVoteOption,

--- a/src/components/molecules/VotePrototype/VotePrototype.tsx
+++ b/src/components/molecules/VotePrototype/VotePrototype.tsx
@@ -31,13 +31,16 @@ const VotePrototype: React.FC<VotePrototypeProps> = ({
 }) => {
   const navigate = useNavigate();
   const accessToken = useNewSelector(selectAccessToken);
-  const [loggedOutVoteOption, setLoggedOutVoteOption] = useState<string | null>(
-    null,
-  );
+  const [loggedOutVoteOption, setLoggedOutVoteOption] = useState<
+    'A' | 'B' | null
+  >(null);
 
   const totalVotes: number = leftVotes + rightVotes;
   const leftPercentage: string = ((leftVotes / totalVotes) * 100).toFixed(1);
   const rightPercentage: string = ((rightVotes / totalVotes) * 100).toFixed(1);
+  const currnetOption: 'A' | 'B' | null = accessToken
+    ? selectedVote
+    : loggedOutVoteOption;
 
   const { isVisible, modalText, showToastModal } = useToastModal();
 
@@ -52,7 +55,8 @@ const VotePrototype: React.FC<VotePrototypeProps> = ({
   useEffect(() => {
     if (!accessToken) {
       const savedVote = localStorage.getItem(`talkpick_${talkPickId}`);
-      if (savedVote) {
+
+      if (savedVote === 'A' || savedVote === 'B') {
         setLoggedOutVoteOption(savedVote);
       }
     }
@@ -107,10 +111,7 @@ const VotePrototype: React.FC<VotePrototypeProps> = ({
           onClick={() => {
             handleVoteButtonClick('A');
           }}
-          css={S.getButtonStyle(
-            'A',
-            accessToken ? selectedVote : loggedOutVoteOption,
-          )}
+          css={S.getButtonStyle('A', currnetOption)}
         >
           {leftButtonText}
         </Button>
@@ -121,10 +122,7 @@ const VotePrototype: React.FC<VotePrototypeProps> = ({
           onClick={() => {
             handleVoteButtonClick('B');
           }}
-          css={S.getButtonStyle(
-            'B',
-            accessToken ? selectedVote : loggedOutVoteOption,
-          )}
+          css={S.getButtonStyle('B', currnetOption)}
         >
           {rightButtonText}
         </Button>

--- a/src/components/molecules/VotePrototype/VotePrototype.tsx
+++ b/src/components/molecules/VotePrototype/VotePrototype.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { NOTICE } from '@/constants/message';
 import Button from '@/components/atoms/Button/Button';
 import VoteBar from '@/components/atoms/VoteBar/VoteBar';
 import ToastModal from '@/components/atoms/ToastModal/ToastModal';
@@ -65,7 +66,7 @@ const VotePrototype: React.FC<VotePrototypeProps> = ({
       setLoggedOutVoteOption(voteOption);
       localStorage.setItem(`talkpick_${talkPickId}`, voteOption);
 
-      showToastModal('투표 결과와 댓글은 로그인 후 확인할 수 있습니다.', () => {
+      showToastModal(NOTICE.REQUIRED.LOGIN, () => {
         navigate('/login', { state: { talkPickId } });
       });
     }

--- a/src/components/molecules/VotePrototype/VotePrototype.tsx
+++ b/src/components/molecules/VotePrototype/VotePrototype.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { NOTICE } from '@/constants/message';
+import { VoteOption, MyVoteOption } from '@/types/vote';
 import Button from '@/components/atoms/Button/Button';
 import VoteBar from '@/components/atoms/VoteBar/VoteBar';
 import ToastModal from '@/components/atoms/ToastModal/ToastModal';
@@ -18,7 +19,7 @@ interface VotePrototypeProps {
   rightButtonText: string;
   leftVotes: number;
   rightVotes: number;
-  selectedVote: 'A' | 'B' | null;
+  selectedVote: MyVoteOption;
 }
 
 const VotePrototype: React.FC<VotePrototypeProps> = ({
@@ -31,14 +32,13 @@ const VotePrototype: React.FC<VotePrototypeProps> = ({
 }) => {
   const navigate = useNavigate();
   const accessToken = useNewSelector(selectAccessToken);
-  const [loggedOutVoteOption, setLoggedOutVoteOption] = useState<
-    'A' | 'B' | null
-  >(null);
+  const [loggedOutVoteOption, setLoggedOutVoteOption] =
+    useState<MyVoteOption>(null);
 
   const totalVotes: number = leftVotes + rightVotes;
   const leftPercentage: string = ((leftVotes / totalVotes) * 100).toFixed(1);
   const rightPercentage: string = ((rightVotes / totalVotes) * 100).toFixed(1);
-  const currnetOption: 'A' | 'B' | null = accessToken
+  const currnetOption: MyVoteOption = accessToken
     ? selectedVote
     : loggedOutVoteOption;
 
@@ -62,7 +62,7 @@ const VotePrototype: React.FC<VotePrototypeProps> = ({
     }
   }, [accessToken, talkPickId]);
 
-  const handleLoggedOutTalkPickVote = (voteOption: 'A' | 'B') => {
+  const handleLoggedOutTalkPickVote = (voteOption: VoteOption) => {
     if (loggedOutVoteOption === voteOption) {
       setLoggedOutVoteOption(null);
       localStorage.removeItem(`talkpick_${talkPickId}`);
@@ -77,8 +77,8 @@ const VotePrototype: React.FC<VotePrototypeProps> = ({
   };
 
   const handleTalkPickVote = (
-    selectedOption: 'A' | 'B' | null,
-    voteOption: 'A' | 'B',
+    selectedOption: MyVoteOption,
+    voteOption: VoteOption,
   ) => {
     if (selectedOption === null) {
       createTalkPickVote(voteOption);
@@ -89,7 +89,7 @@ const VotePrototype: React.FC<VotePrototypeProps> = ({
     }
   };
 
-  const handleVoteButtonClick = (voteOption: 'A' | 'B') => {
+  const handleVoteButtonClick = (voteOption: VoteOption) => {
     if (accessToken) {
       handleTalkPickVote(selectedVote, voteOption);
     } else {

--- a/src/components/organisms/CommentsSection/CommentsSection.tsx
+++ b/src/components/organisms/CommentsSection/CommentsSection.tsx
@@ -11,6 +11,7 @@ import ToastModal from '@/components/atoms/ToastModal/ToastModal';
 import ToggleGroup, {
   ToggleGroupItem,
 } from '@/components/atoms/ToggleGroup/ToggleGroup';
+import { NOTICE } from '@/constants/message';
 import { createRangeArray } from '@/utils/array';
 import CommentItem from '@/components/molecules/CommentItem/CommentItem';
 import { useCreateCommentMutation } from '@/hooks/api/comment/useCreateCommentMutation';
@@ -78,9 +79,7 @@ const CommentsSection = ({
         {!isMyTalkPick && !voted && (
           <div css={S.loggedOutBackground}>
             <div css={S.toastModalWrapper}>
-              <ToastModal bgColor="black">
-                투표 후에 확인할 수 있습니다.
-              </ToastModal>
+              <ToastModal bgColor="black">{NOTICE.REQUIRED.VOTE}</ToastModal>
             </div>
           </div>
         )}

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -61,6 +61,13 @@ export const SUCCESS = {
   },
 } as const;
 
+export const NOTICE = {
+  REQUIRED: {
+    LOGIN: '투표 결과와 댓글은 로그인 후 확인할 수 있습니다.',
+    VOTE: '투표 후에 확인할 수 있습니다.',
+  },
+} as const;
+
 export const NULL = {
   POSTS: '작성한 게시글이 없습니다.',
   COMMENTS: '작성한 댓글이 없습니다.',

--- a/src/hooks/login/useLoginForm.ts
+++ b/src/hooks/login/useLoginForm.ts
@@ -11,7 +11,7 @@ import { ERROR } from '../../constants/message';
 import useInputs from '../common/useInputs';
 import { validateLoginForm } from './validateLoginForm';
 
-export const useLoginForm = () => {
+export const useLoginForm = (pathTalkPickId: number | undefined) => {
   const initialState: Pick<MemberForm, 'email' | 'password'> = {
     email: localStorage.getItem('savedEmail') ?? '',
     password: '',
@@ -51,7 +51,11 @@ export const useLoginForm = () => {
       localStorage.setItem('savedEmail', form.email);
 
       setTimeout(() => {
-        navigate('/');
+        if (pathTalkPickId) {
+          navigate(`/talkpick/${pathTalkPickId}`);
+        } else {
+          navigate('/');
+        }
       }, 2000);
     },
 

--- a/src/hooks/modal/useToastModal.ts
+++ b/src/hooks/modal/useToastModal.ts
@@ -4,12 +4,13 @@ const useToastModal = () => {
   const [isVisible, setIsVisible] = useState(false);
   const [modalText, setModalText] = useState<string | null>(null);
 
-  const showToastModal = (message: string) => {
+  const showToastModal = (message: string, callback?: () => void) => {
     setModalText(message);
     setIsVisible(true);
 
     const modalTimer = setTimeout(() => {
       setIsVisible(false);
+      callback?.();
     }, 2000);
 
     return () => clearTimeout(modalTimer);

--- a/src/hooks/modal/useToastModal.ts
+++ b/src/hooks/modal/useToastModal.ts
@@ -1,20 +1,31 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 const useToastModal = () => {
   const [isVisible, setIsVisible] = useState(false);
   const [modalText, setModalText] = useState<string | null>(null);
+  const modalTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const showToastModal = (message: string, callback?: () => void) => {
     setModalText(message);
     setIsVisible(true);
 
-    const modalTimer = setTimeout(() => {
+    if (modalTimerRef.current) {
+      clearTimeout(modalTimerRef.current);
+    }
+
+    modalTimerRef.current = setTimeout(() => {
       setIsVisible(false);
       callback?.();
     }, 2000);
-
-    return () => clearTimeout(modalTimer);
   };
+
+  useEffect(() => {
+    return () => {
+      if (modalTimerRef.current) {
+        clearTimeout(modalTimerRef.current);
+      }
+    };
+  }, []);
 
   return {
     isVisible,

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,13 +1,21 @@
 import React from 'react';
-import LoginForm from '@/components/molecules/LoginForm/LoginForm';
 import { LogoLarge } from '@/assets';
+import LoginForm from '@/components/molecules/LoginForm/LoginForm';
+import { useLocation } from 'react-router-dom';
 import * as S from './LoginPage.style';
 
+interface State {
+  talkPickId: number;
+}
+
 const LoginPage = () => {
+  const location = useLocation();
+  const state = location.state as State;
+
   return (
     <div css={S.loginContainer}>
       <LogoLarge css={S.logoStyle} />
-      <LoginForm withSignInText />
+      <LoginForm withSignInText pathTalkPickId={state?.talkPickId} />
     </div>
   );
 };

--- a/src/pages/TalkPickPage/TalkPickPage.tsx
+++ b/src/pages/TalkPickPage/TalkPickPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useNewSelector } from '@/store';
 import { selectAccessToken } from '@/store/auth';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { useParseJwt } from '@/hooks/common/useParseJwt';
 import { useMemberQuery } from '@/hooks/api/member/useMemberQuery';
 import { useCommentsQuery } from '@/hooks/api/comment/useCommentsQuery';
@@ -24,12 +24,14 @@ const TalkPickPage = () => {
   const accessToken = useNewSelector(selectAccessToken);
   const { member } = useMemberQuery(useParseJwt(accessToken).memberId);
 
+  const { talkPickId } = useParams();
   const location = useLocation();
   const state = location.state as State;
-  const talkPickId = state?.talkPickId;
+
+  const id = state?.talkPickId ?? Number(talkPickId);
   const isTodayTalkPick = state?.isTodayTalkPick;
 
-  const { talkPick } = useTalkPickDetailQuery(talkPickId);
+  const { talkPick } = useTalkPickDetailQuery(id);
 
   const toggleItem: ToggleGroupItem[] = [
     {
@@ -43,7 +45,7 @@ const TalkPickPage = () => {
   ];
 
   const { comments } = useCommentsQuery(
-    talkPickId,
+    id,
     {
       page: selectedPage - 1,
       size: 7,
@@ -52,7 +54,7 @@ const TalkPickPage = () => {
   );
 
   const { bestComments } = useBestCommentsQuery(
-    talkPickId,
+    id,
     {
       page: selectedPage - 1,
       size: 7,
@@ -69,7 +71,7 @@ const TalkPickPage = () => {
       />
       <div css={S.commentsWrapStyle}>
         <CommentsSection
-          talkPickId={talkPickId}
+          talkPickId={id}
           talkPickWriter={talkPick?.writer ?? ''}
           commentList={selectedValue === 'trend' ? bestComments : comments}
           toggleItem={toggleItem}

--- a/src/stories/molecules/VotePrototype.stories.tsx
+++ b/src/stories/molecules/VotePrototype.stories.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import VotePrototype from '@/components/molecules/VotePrototype/VotePrototype';
+import store from '@/store';
+import { Provider } from 'react-redux';
 import ReactQueryProvider from '@/providers/ReactQueryProvider';
+import { BrowserRouter as Router } from 'react-router-dom';
 import type { Meta, StoryObj } from '@storybook/react';
+import { setToken } from '@/store/auth';
 import { storyContainer, storyInnerContainer } from '@/stories/story.styles';
 
 const meta = {
@@ -37,9 +41,13 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <ReactQueryProvider>
-        <Story />
-      </ReactQueryProvider>
+      <Provider store={store}>
+        <ReactQueryProvider>
+          <Router>
+            <Story />
+          </Router>
+        </ReactQueryProvider>
+      </Provider>
     ),
   ],
 } satisfies Meta<typeof VotePrototype>;
@@ -47,9 +55,16 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  play: () => {
+    store.dispatch(setToken('accessToken'));
+  },
+};
 
 export const All: Story = {
+  play: () => {
+    store.dispatch(setToken('accessToken'));
+  },
   render: (args) => (
     <ul css={storyContainer}>
       <li css={storyInnerContainer}>

--- a/src/stories/organisms/TalkPickSection.stories.tsx
+++ b/src/stories/organisms/TalkPickSection.stories.tsx
@@ -5,23 +5,26 @@ import { Provider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
 import ReactQueryProvider from '@/providers/ReactQueryProvider';
 import type { Meta, StoryObj } from '@storybook/react';
+import { setToken } from '@/store/auth';
 import TalkPickSection from '@/components/organisms/TalkPickSection/TalkPickSection';
 
 const defaultTodayTalkPick: TalkPickDetail = {
   id: 0,
-  title: '새우 껍질 논쟁, 당신의 선택은?',
-  content:
-    '(더미글이에욤) 건강과 지속 가능성을 추구하는 이들을 위해, 맛과 영양이 가득한 채식 요리 레시피를 소개합니다. 이 글에서는 간단하지만 맛있는 채식 요리 10가지를 선보입니다. 첫 번째 레시피는 아보카도 토스트, 아침 식사로 완벽하며 영양소가 풍부합니다. 두 번째는 콩과 야채를 사용한 푸짐한 채식 칠리, 포만감을 주는 동시에 영양소를 공급합니다. 세 번째는 색다른 맛의 채식 패드타이, 고소한 땅콩 소스로 풍미를 더합니다. 네 번째는 간단하고 건강한 콥 샐러드, 신선한 야채와 단백질이 가득합니다. 다섯 번째로는 향긋한 허브와 함께하는 채식 리조또, 크리미한 맛이 일품입니다. 여섯 번째는 에너지를 주는 채식 스무디 볼, 과일과 견과류의 완벽한 조합입니다. 여덟 번째는 채식 파스타 프리마베라, 신선한 야채와 토마토 소스의 조화가 뛰어납니다. 아홉 번째는 채식 볶음밥, 풍부한 맛과 영양으로 가득 차 있습니다. 마지막으로, 식사 후 달콤한 마무리를 위한 채식 초콜릿 케이크, 건강한 재료로 만들어 죄책감 없는 달콤함을 선사합니다. 이 레시피들은 채식을 선호하는 이들에게 새로운 요리 아이디어를 제공하며, 채식이 얼마나 다채롭고 맛있을 수 있는지 보여줍니다. 건강한 라이프스타일을 추구하는 모든 이들에게 이 레시피들이 영감을 줄 것입니다.',
+  baseFields: {
+    title: '새우 껍질 논쟁, 당신의 선택은?',
+    optionA: '상관없다다다다다다다',
+    optionB: '상관 있다',
+    sourceUrl: '출처',
+    content:
+      '(더미글이에욤) 건강과 지속 가능성을 추구하는 이들을 위해, 맛과 영양이 가득한 채식 요리 레시피를 소개합니다. 이 글에서는 간단하지만 맛있는 채식 요리 10가지를 선보입니다. 첫 번째 레시피는 아보카도 토스트, 아침 식사로 완벽하며 영양소가 풍부합니다. 두 번째는 콩과 야채를 사용한 푸짐한 채식 칠리, 포만감을 주는 동시에 영양소를 공급합니다. 세 번째는 색다른 맛의 채식 패드타이, 고소한 땅콩 소스로 풍미를 더합니다. 네 번째는 간단하고 건강한 콥 샐러드, 신선한 야채와 단백질이 가득합니다. 다섯 번째로는 향긋한 허브와 함께하는 채식 리조또, 크리미한 맛이 일품입니다. 여섯 번째는 에너지를 주는 채식 스무디 볼, 과일과 견과류의 완벽한 조합입니다. 여덟 번째는 채식 파스타 프리마베라, 신선한 야채와 토마토 소스의 조화가 뛰어납니다. 아홉 번째는 채식 볶음밥, 풍부한 맛과 영양으로 가득 차 있습니다. 마지막으로, 식사 후 달콤한 마무리를 위한 채식 초콜릿 케이크, 건강한 재료로 만들어 죄책감 없는 달콤함을 선사합니다. 이 레시피들은 채식을 선호하는 이들에게 새로운 요리 아이디어를 제공하며, 채식이 얼마나 다채롭고 맛있을 수 있는지 보여줍니다. 건강한 라이프스타일을 추구하는 모든 이들에게 이 레시피들이 영감을 줄 것입니다.',
+  },
   summary: {
     summaryFirstLine: '남친이 어쩌고 저쩌고 잘못했네 안했네 대충 더미글',
     summarySecondLine: '남친이 친구 새우 껍질을 어쩌고 저쩌고 뭐라뭐라',
     summaryThirdLine: '나 너무 속상한데 이걸 찬성해 말어',
   },
-  optionA: '상관없다다다다다다다',
-  optionB: '상관 있다',
-  sourceUrl: '출처',
   imgUrls: [],
-  imgStoredNames: [],
+  fileIds: [],
   votesCountOfOptionA: 1963,
   votesCountOfOptionB: 2635,
   views: 35254,
@@ -30,7 +33,7 @@ const defaultTodayTalkPick: TalkPickDetail = {
   votedOption: 'A',
   writer: '닉네임593',
   createdAt: '2024-08-04',
-  isUpdated: false,
+  isEdited: false,
 };
 
 const meta = {
@@ -61,4 +64,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  play: () => {
+    store.dispatch(setToken('accessToken'));
+  },
+};

--- a/src/types/talk-pick.ts
+++ b/src/types/talk-pick.ts
@@ -53,14 +53,6 @@ export interface TempTalkPick extends NewTalkPick {
   imgUrls: string[];
 }
 
-export type TalkPick = {
-  title: string;
-  content: string;
-  summary: TalkPickSummary;
-  optionA: string;
-  optionB: string;
-};
-
 export type TodayTalkPick = {
   id: number;
   title: string;

--- a/src/types/talk-pick.ts
+++ b/src/types/talk-pick.ts
@@ -1,15 +1,19 @@
 import { PaginationType } from './pagination';
 
-export type TalkPickDetail = {
-  id: number;
+export type TalkPickField = {
   title: string;
   content: string;
-  summary: TalkPickSummary;
   optionA: string;
   optionB: string;
   sourceUrl: string;
+};
+
+export type TalkPickDetail = {
+  id: number;
+  baseFields: TalkPickField;
+  summary: TalkPickSummary;
   imgUrls: string[];
-  imgStoredNames: string[];
+  fileIds: number[];
   votesCountOfOptionA: number;
   votesCountOfOptionB: number;
   views: number;
@@ -18,7 +22,7 @@ export type TalkPickDetail = {
   votedOption: 'A' | 'B' | null;
   writer: string;
   createdAt: string;
-  isUpdated: boolean;
+  isEdited: boolean;
 };
 
 export type TalkPickSummary = {
@@ -40,25 +44,26 @@ export interface TalkPickListPagination extends PaginationType {
   content: TalkPickListItem[];
 }
 
-export type TalkPick = Pick<
-  TalkPickDetail,
-  'title' | 'content' | 'summary' | 'optionA' | 'optionB'
->;
-
-export type TodayTalkPick = Pick<
-  TalkPickDetail,
-  'id' | 'title' | 'optionA' | 'optionB'
->;
-
 export type NewTalkPick = {
-  title: string;
-  content: string;
-  optionA: string;
-  optionB: string;
-  sourceUrl?: string;
-  storedNames: string[];
+  baseFields: TalkPickField;
+  fileIds: number[];
 };
 
 export interface TempTalkPick extends NewTalkPick {
   imgUrls: string[];
 }
+
+export type TalkPick = {
+  title: string;
+  content: string;
+  summary: TalkPickSummary;
+  optionA: string;
+  optionB: string;
+};
+
+export type TodayTalkPick = {
+  id: number;
+  title: string;
+  optionA: string;
+  optionB: string;
+};

--- a/src/types/vote.ts
+++ b/src/types/vote.ts
@@ -1,6 +1,2 @@
-export type VoteResult = {
-  optionACount: number;
-  optionBCount: number;
-};
-
 export type VoteOption = 'A' | 'B';
+export type MyVoteOption = VoteOption | null;


### PR DESCRIPTION
## 💡 작업 내용

- [x] 비회원일 경우 투표 바 밑으로 블러 처리 구현
- [x] 비회원으로 톡픽 투표 시 투표 기록이 남도록 구현
- [x] 비회원 톡픽 투표 후 토스트 모달 2초 제시 후 로그인 페이지로 이동
- [x] 위의 플로우로 로그인 이후 해당 톡픽 페이지로 이동
- [x] useParams를 이용하여 url에 톡픽 id 입력 시 톡픽 페이지 확인 가능하도록 수정  

## 💡 자세한 설명
### ✅ useToastModal
- `showToastModal` 함수에 선택적으로 함수를 넘겨주어 토스트 모달이 2초 제시된 이후 실행될 수 있도록 수정했습니다.

### ✅ useLoginForm
- 로그인 이후 메인 페이지가 아닌 톡픽 상세 페이지로 이동되어야 하기 때문에 `pathTalkPickId` 값을 넘겨주어 해당 값이 존재할 경우에만 해당 톡픽 상세 페이지로 이동되도록 구현했습니다.
- url의 id로 톡픽 조회가 가능하도록 TalkPickPage에서 `useParams`를 사용했습니다. 

### ✅ VotePrototype
- 비회원 상태일 경우 localStorage를 사용하여 톡픽 투표 기록을 남겨주는 함수 `handleLoggedOutTalkPickVote`를 선언해주었고, 기존의 `handleVoteButtonClick`에 연결해주었습니다. 
```javascript
  const handleLoggedOutTalkPickVote = (voteOption: 'A' | 'B') => {
    if (loggedOutVoteOption === voteOption) {
      setLoggedOutVoteOption(null);
      localStorage.removeItem(`talkpick_${talkPickId}`);
    } else {
      setLoggedOutVoteOption(voteOption);
      localStorage.setItem(`talkpick_${talkPickId}`, voteOption);

      showToastModal(NOTICE.REQUIRED.LOGIN, () => {
        navigate('/login', { state: { talkPickId } });
      });
    }
  };
```

![녹음-2024-11-12-011927](https://github.com/user-attachments/assets/a7f4788e-569d-430d-8e88-4a73deb25484)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #213 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 로그인 폼에 `pathTalkPickId` 속성을 추가하여 동적 데이터 처리가 가능해졌습니다.
	- 로그인 페이지에서 `pathTalkPickId`를 기반으로 조건부 렌더링을 지원합니다.
	- 투표 프로토타입에서 비로그인 사용자를 위한 투표 기능이 추가되었습니다.
	- 새로운 상수 `NOTICE`를 추가하여 로그인 및 투표 관련 메시지를 중앙 집중화했습니다.

- **버그 수정**
	- 토스트 모달의 콜백 기능이 추가되어 모달 숨김 후 추가 작업을 수행할 수 있게 되었습니다.

- **문서화**
	- 코드 유지보수성을 높이기 위해 하드코딩된 메시지를 상수로 대체했습니다.

- **스타일**
	- 투표 프로토타입의 스타일이 개선되어 사용자 인터페이스가 향상되었습니다.

- **리팩토링**
	- 모달 관리 로직을 간소화하여 코드의 복잡성을 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->