### PR TITLE
chore: 배포 환경에서 AxiosInterceptor 설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "balance-talk",
+  "name": "pick-o",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "balance-talk",
+      "name": "pick-o",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "balance-talk",
+  "name": "pick-o",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
-<html lang="en">
+<html lang="kr">
   <head>
     <meta charset="UTF-8" />
-    <title>BalanceTalk</title>
+    <title>PICK-O</title>
   </head>
 
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,4 @@
-<html lang="kr">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <title>PICK-O</title>

--- a/src/api/interceptor.ts
+++ b/src/api/interceptor.ts
@@ -9,10 +9,13 @@ export interface AxiosErrorResponse {
   message?: string;
 }
 
+const baseURL =
+  process.env.NODE_ENV === 'production' ? process.env.API_URL : '/api';
+
 export const axiosInstance = axios.create({
   // baseURL: process.env.API_URL,
   // baseURL: '/api',
-  baseURL: process.env.MSW ? process.env.API_URL : '/api',
+  baseURL,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = (env) => {
   }
 
   return {
-    name: 'balance-talk',
+    name: 'PICK-O',
     mode: DEV ? 'development' : 'production',
     entry: './src/index.tsx',
     module: {


### PR DESCRIPTION
## 💡 작업 내용

- [x] 설정 파일(package.json, package-lock.json, webpack.config.js, index.html) 이름을 `PICK-O` 로 변경
- [x] production 환경에서 baseUrl 설정 추가

## 💡 자세한 설명

### ✅ Intercepter.ts(src/api/intercepter)

```typescript
  baseURL: process.env.MSW ? process.env.API_URL : '/api',
```
기존에는 MSW 유무에 따라 baseUrl을 분기처리 하였고, MSW를 사용하지 않는 경우 `webpack.config.js`에서 설정해준 프록시 주소로 연결하는 로직이 구현되어 있었습니다.

현재는 msw를 사용하지 않기 때문에
```typescript
const baseURL =
  process.env.NODE_ENV === 'production' ? process.env.API_URL : '/api';
```
와 같이 build 환경이 `development` 유무에 따라 baseUrl을 분기처리 하였습니다.

### ✅ 설정 파일 네이밍 수정
- package.json 의 경우 대문자 입력이 불가능하여 `PICK-O` 가 아닌 `pick-o`로 수정하였습니다.
- package-lock.json은 직접 수정이 아닌 package.json 수정 후 npm install을 통해 수정하였습니다. 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항(선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #218 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 프로젝트 이름이 "balance-talk"에서 "PICK-O"로 변경되었습니다.
	- 웹페이지 제목이 "BalanceTalk"에서 "PICK-O"로 업데이트되었습니다.
	- HTML 문서의 언어 속성이 "en"에서 "ko"로 변경되었습니다.

- **버그 수정**
	- API 엔드포인트 구성의 유연성을 향상시켰습니다.

- **문서화**
	- 변경된 프로젝트 이름과 관련된 메타데이터가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->