### PR TITLE
refactor: 검색결과 페이지 스켈레톤 적용

### DIFF
--- a/src/components/atoms/SearchResultCardSkeleton/SearchResultCardSkeleton.style.ts
+++ b/src/components/atoms/SearchResultCardSkeleton/SearchResultCardSkeleton.style.ts
@@ -3,6 +3,7 @@ import color from '@/styles/color';
 
 export const gridContainer = css({
   display: 'grid',
+  width: '1146px',
   gridTemplateColumns: 'repeat(3, 1fr)',
   gap: '20px',
 });

--- a/src/components/atoms/SearchResultListSkeleton/SearchResultListSkeleton.style.ts
+++ b/src/components/atoms/SearchResultListSkeleton/SearchResultListSkeleton.style.ts
@@ -4,6 +4,11 @@ import color from '@/styles/color';
 export const listContainer = css({
   display: 'flex',
   flexDirection: 'column',
+  width: '1145px',
+  border: `1px solid ${color.GY[2]}`,
+  borderRadius: '10px',
+  alignItems: 'center',
+  padding: '20px 0',
 });
 
 export const contentContainer = css({

--- a/src/components/organisms/SearchGameListSection/SearchGameListSection.tsx
+++ b/src/components/organisms/SearchGameListSection/SearchGameListSection.tsx
@@ -6,6 +6,7 @@ import SearchGameList, {
 } from '@/components/molecules/SearchGameList/SearchGameList';
 import { generatePageNumbers } from '@/utils/pagination';
 import { NoResultsMessage } from '@/components/atoms/NoResultsMessage/NoResultsMessage';
+import SearchResultCardSkeleton from '@/components/atoms/SearchResultCardSkeleton/SearchResultCardSkeleton';
 import * as S from './SearchGameListSection.style';
 
 interface SearchGameListSectionProps {
@@ -32,7 +33,11 @@ const SearchGameListSection = ({
   const pages = generatePageNumbers(totalPages);
 
   if (isLoading) {
-    return <div>스켈레톤 준비중...</div>;
+    return (
+      <div css={S.container}>
+        <SearchResultCardSkeleton count={9} />
+      </div>
+    );
   }
 
   if (gameList.length === 0) {

--- a/src/components/organisms/SearchGameListSection/SearchGameListSection.tsx
+++ b/src/components/organisms/SearchGameListSection/SearchGameListSection.tsx
@@ -35,7 +35,21 @@ const SearchGameListSection = ({
   if (isLoading) {
     return (
       <div css={S.container}>
-        <SearchResultCardSkeleton count={9} />
+        <div css={S.titleWrapper}>
+          <div>밸런스게임</div>
+          <ToggleGroup selectedValue={sort} onClick={onSortChange} />
+        </div>
+        <div css={S.contentWrapper}>
+          <SearchResultCardSkeleton count={9} />
+        </div>
+        <div css={S.paginationWrapper}>
+          <Pagination
+            pages={pages}
+            selected={selectedPage}
+            maxPage={totalPages}
+            onChangeNavigate={onPageChange}
+          />
+        </div>
       </div>
     );
   }

--- a/src/components/organisms/SearchGameResult/SearchGameResult.tsx
+++ b/src/components/organisms/SearchGameResult/SearchGameResult.tsx
@@ -6,14 +6,20 @@ import SearchGameList, {
 import { NoResultsMessage } from '@/components/atoms/NoResultsMessage/NoResultsMessage';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PATH } from '@/constants/path';
+import SearchResultCardSkeleton from '@/components/atoms/SearchResultCardSkeleton/SearchResultCardSkeleton';
 import * as S from './SearchGameResult.style';
 
 interface SearchGameResultProps {
   gameList: GameItem[];
   keyword: string;
+  isLoading: boolean;
 }
 
-const SearchGameResult = ({ gameList, keyword }: SearchGameResultProps) => {
+const SearchGameResult = ({
+  gameList,
+  keyword,
+  isLoading,
+}: SearchGameResultProps) => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const handleButtonClick = () => {
@@ -21,6 +27,20 @@ const SearchGameResult = ({ gameList, keyword }: SearchGameResultProps) => {
   };
 
   const hasResults = gameList.length > 0;
+
+  if (isLoading) {
+    return (
+      <div css={S.container}>
+        <div css={S.titleWrapper}>
+          <div>밸런스게임</div>
+          <MoreButton onClick={handleButtonClick} />
+        </div>
+        <div css={S.contentWRapper}>
+          <SearchResultCardSkeleton count={9} />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div css={S.container}>

--- a/src/components/organisms/SearchTalkPickListSection/SearchTalkPickListSection.tsx
+++ b/src/components/organisms/SearchTalkPickListSection/SearchTalkPickListSection.tsx
@@ -6,6 +6,7 @@ import SearchTalkPickList from '@/components/molecules/SearchTalkPickList/Search
 import Pagination from '@/components/atoms/Pagination/Pagination';
 import { generatePageNumbers } from '@/utils/pagination';
 import { NoResultsMessage } from '@/components/atoms/NoResultsMessage/NoResultsMessage';
+import SearchResultListSkeleton from '@/components/atoms/SearchResultListSkeleton/SearchResultListSkeleton';
 import * as S from './SearchTalkPickListSection.style';
 
 interface SearchTalkPickSectionProps {
@@ -32,7 +33,11 @@ const SearchTalkPickListSection = ({
   const pages = generatePageNumbers(totalPages);
 
   if (isLoading) {
-    return <div>스켈레톤 준비중...</div>;
+    return (
+      <div css={S.container}>
+        <SearchResultListSkeleton length={10} />
+      </div>
+    );
   }
 
   if (searchTalkPickList.length === 0) {

--- a/src/components/organisms/SearchTalkPickListSection/SearchTalkPickListSection.tsx
+++ b/src/components/organisms/SearchTalkPickListSection/SearchTalkPickListSection.tsx
@@ -35,7 +35,21 @@ const SearchTalkPickListSection = ({
   if (isLoading) {
     return (
       <div css={S.container}>
-        <SearchResultListSkeleton length={10} />
+        <div css={S.titleWrapper}>
+          <div>톡픽</div>
+          <ToggleGroup selectedValue={sort} onClick={onSortChange} />
+        </div>
+        <div css={S.contentWrapper}>
+          <SearchResultListSkeleton length={10} />
+        </div>
+        <div css={S.paginationWrapper}>
+          <Pagination
+            pages={pages}
+            selected={selectedPage}
+            maxPage={totalPages}
+            onChangeNavigate={onPageChange}
+          />
+        </div>
       </div>
     );
   }

--- a/src/components/organisms/SearchTalkPickResult/SearchTalkPickResult.tsx
+++ b/src/components/organisms/SearchTalkPickResult/SearchTalkPickResult.tsx
@@ -5,16 +5,19 @@ import SearchTalkPickList from '@/components/molecules/SearchTalkPickList/Search
 import { NoResultsMessage } from '@/components/atoms/NoResultsMessage/NoResultsMessage';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PATH } from '@/constants/path';
+import SearchResultListSkeleton from '@/components/atoms/SearchResultListSkeleton/SearchResultListSkeleton';
 import * as S from './SearchTalkPickResult.style';
 
 interface SearchTalkPickResultProps {
   searchTalkPickList: SearchTalkPickItemProps[];
   keyword: string;
+  isLoading: boolean;
 }
 
 const SearchTalkPickResult = ({
   searchTalkPickList,
   keyword,
+  isLoading,
 }: SearchTalkPickResultProps) => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -25,6 +28,18 @@ const SearchTalkPickResult = ({
       `/result/${PATH.SEARCH.TALKPICK}?query=${searchParams.get('query')}`,
     );
   };
+
+  if (isLoading) {
+    return (
+      <div css={S.container}>
+        <div css={S.titleWrapper}>
+          <div>톡픽</div>
+          <MoreButton onClick={handleButtonClick} />
+        </div>
+        <SearchResultListSkeleton length={4} />
+      </div>
+    );
+  }
 
   return (
     <div css={S.container}>

--- a/src/pages/SearchResultsPage/SearchResultsPage.style.ts
+++ b/src/pages/SearchResultsPage/SearchResultsPage.style.ts
@@ -4,7 +4,7 @@ export const container = css({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  paddingTop: '47px',
+  paddingTop: '147px',
   width: '100%',
   maxWidth: '1147px',
 });

--- a/src/pages/SearchResultsPage/SearchResultsPage.tsx
+++ b/src/pages/SearchResultsPage/SearchResultsPage.tsx
@@ -8,8 +8,6 @@ import useTagFilter from '@/hooks/search/useTagFilter';
 import useSearchQuery from '@/hooks/search/useSearchQuery';
 import Divider from '@/components/atoms/Divider/Divider';
 import SearchResultBarContainer from '@/components/organisms/SearchResultBarContainer/SearchResultBarContainer';
-import SearchResultListSkeleton from '@/components/atoms/SearchResultListSkeleton/SearchResultListSkeleton';
-import SearchResultCardSkeleton from '@/components/atoms/SearchResultCardSkeleton/SearchResultCardSkeleton';
 import * as S from './SearchResultsPage.style';
 
 const SearchResultsPage = () => {
@@ -29,15 +27,6 @@ const SearchResultsPage = () => {
   );
 
   const renderResults = () => {
-    if (isTalkPickLoading || isGameLoading) {
-      return (
-        <div css={S.resultsWrapper}>
-          <SearchResultListSkeleton length={4} />
-          <SearchResultCardSkeleton count={4} />
-        </div>
-      );
-    }
-
     const noTalkPickResults = talkPickResults.length === 0;
     const noGameResults = gameResults.length === 0;
 
@@ -54,8 +43,13 @@ const SearchResultsPage = () => {
         <SearchTalkPickResult
           searchTalkPickList={talkPickResults}
           keyword={query}
+          isLoading={isTalkPickLoading}
         />
-        <SearchGameResult gameList={gameResults} keyword={query} />
+        <SearchGameResult
+          gameList={gameResults}
+          keyword={query}
+          isLoading={isGameLoading}
+        />
       </div>
     );
   };

--- a/src/pages/SearchResultsPage/SearchResultsPage.tsx
+++ b/src/pages/SearchResultsPage/SearchResultsPage.tsx
@@ -8,6 +8,8 @@ import useTagFilter from '@/hooks/search/useTagFilter';
 import useSearchQuery from '@/hooks/search/useSearchQuery';
 import Divider from '@/components/atoms/Divider/Divider';
 import SearchResultBarContainer from '@/components/organisms/SearchResultBarContainer/SearchResultBarContainer';
+import SearchResultListSkeleton from '@/components/atoms/SearchResultListSkeleton/SearchResultListSkeleton';
+import SearchResultCardSkeleton from '@/components/atoms/SearchResultCardSkeleton/SearchResultCardSkeleton';
 import * as S from './SearchResultsPage.style';
 
 const SearchResultsPage = () => {
@@ -28,7 +30,12 @@ const SearchResultsPage = () => {
 
   const renderResults = () => {
     if (isTalkPickLoading || isGameLoading) {
-      return null;
+      return (
+        <div css={S.resultsWrapper}>
+          <SearchResultListSkeleton length={4} />
+          <SearchResultCardSkeleton count={4} />
+        </div>
+      );
     }
 
     const noTalkPickResults = talkPickResults.length === 0;

--- a/src/stories/organisms/SearchGameListSection.stories.tsx
+++ b/src/stories/organisms/SearchGameListSection.stories.tsx
@@ -70,6 +70,18 @@ export const All: Story = {
             onSortChange={handleSortChange}
           />
         </div>
+        <div>
+          <h3>로딩중</h3>
+          <SearchGameListSection
+            {...args}
+            gameList={gameListSample.slice(9, 18)}
+            totalPages={2}
+            selectedPage={2}
+            sort={sort}
+            isLoading
+            onSortChange={handleSortChange}
+          />
+        </div>
       </>
     );
   },

--- a/src/stories/organisms/SearchGameResult.stories.tsx
+++ b/src/stories/organisms/SearchGameResult.stories.tsx
@@ -37,6 +37,7 @@ export const Default: Story = {
   args: {
     gameList: gameListSample,
     keyword: '유진',
+    isLoading: false,
   },
 };
 

--- a/src/stories/organisms/SearchTalkPickResult.stories.tsx
+++ b/src/stories/organisms/SearchTalkPickResult.stories.tsx
@@ -13,6 +13,7 @@ const SearchTalkPickItems: SearchTalkPickItemProps[] = Array.from(
     content: '우하하우하하 내용입니다.',
     firstImgUrl: SampleWhole,
     keyword: '정국',
+    isLoading: false,
   }),
 );
 
@@ -23,6 +24,7 @@ const meta: Meta<typeof SearchTalkPickResult> = {
   args: {
     searchTalkPickList: SearchTalkPickItems,
     keyword: '정국',
+    isLoading: false,
   },
   decorators: [
     (Story) => (


### PR DESCRIPTION
## 💡 작업 내용

- [x] 검색결과 페이지 스켈레톤 ui 적용
- [x] 검색 결과 필터링 시 최신순, 인기순에 asc, desc 적용(#224 에서 반영됨)
- [x] 검색 결과 클릭 시 해당 항목으로 라우팅(#224 에서 반영됨)

## 💡 자세한 설명
### ✅ SearchResultListSkeleton
올바르게 적용되어 있지 않던 테두리 값, 중앙 정렬 및 패딩을 해당 스켈레톤에서 처리하도록 수정하였습니다.

### ✅ SearchResultCardSkeleton
이제 해당 스켈레톤은 최상위에 width 값을 가진 태그를 가집니다.

### ✅ 스켈레톤 처리
이제 페이지 내부에서 스켈레톤 처리가 아닌 organisms 컴포넌트에서 `isLoading 을 props로 전달받아` 로딩 중일 때 스켈레톤 처리를 합니다.

```typescript
  <SearchTalkPickResult
    searchTalkPickList={talkPickResults}
    keyword={query}
    isLoading={isTalkPickLoading}
  />
  <SearchGameResult
    gameList={gameResults}
    keyword={query}
    isLoading={isGameLoading}
  />
```

해당하는 organisms 컴포넌트는 **SearchTalkPickResult, SearchGameResult, SearchGameListSection, SearchTalkPickListSection** 입니다.

+) 해당 처리는 디자인에서 의도된 순수 내용만을 스켈레톤화 하기 위해 isLoading 값을 organisms 컴포넌트에 전달 하도록 하였습니다.

https://github.com/user-attachments/assets/ae7913eb-a2c3-4cee-a449-1bf71f2f4b40




## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
검색결과 페이지 관련 라우팅 설정, 스토리북 에러(GameItem 타입 관련)는 #224 에서 처리되었습니다.

toggleGroup 과 관련된 최신순 역시 #224에서 처리 완료 되었습니다.

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #210 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 검색 결과 로딩 상태를 표시하는 스켈레톤 로더 추가.
	- 로딩 중에 사용자 인터페이스 개선을 위한 구조적 레이아웃 변경.
  
- **스타일 개선**
	- `SearchResultCardSkeleton` 및 `SearchResultListSkeleton`의 스타일 속성 추가.
	- `SearchResultsPage`의 상단 패딩 값 변경.

- **버그 수정**
	- 로딩 상태에 관계없이 검색 결과를 표시하도록 로직 수정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->