### PR TITLE
fix: 옵셔널 체이닝 미사용으로 인한 summaryStatus undefined 접근 에러 수정

### DIFF
--- a/src/components/molecules/SummaryBox/SummaryBox.tsx
+++ b/src/components/molecules/SummaryBox/SummaryBox.tsx
@@ -7,10 +7,13 @@ import * as S from './SummaryBox.style';
 
 export interface SummaryBoxProps {
   summary?: TalkPickSummary;
-  summaryStatus: 'PENDING' | 'SUCCESS' | 'FAIL' | 'NOT_REQUIRED';
+  summaryStatus?: 'PENDING' | 'SUCCESS' | 'FAIL' | 'NOT_REQUIRED';
 }
 
-const SummaryBox = ({ summary, summaryStatus }: SummaryBoxProps) => {
+const SummaryBox = ({
+  summary,
+  summaryStatus = 'PENDING',
+}: SummaryBoxProps) => {
   const contentMap: Record<
     'PENDING' | 'SUCCESS' | 'FAIL' | 'NOT_REQUIRED',
     React.ReactNode

--- a/src/components/organisms/TalkPickSection/TalkPickSection.tsx
+++ b/src/components/organisms/TalkPickSection/TalkPickSection.tsx
@@ -192,7 +192,7 @@ const TalkPickSection = ({
         <div css={S.talkPickContentWrapper}>
           <SummaryBox
             summary={talkPick?.summary}
-            summaryStatus={talkPick.summaryStatus}
+            summaryStatus={talkPick?.summaryStatus}
           />
           {isExpanded && (
             <div css={S.talkPickContent}>


### PR DESCRIPTION
## 💡 작업 내용

- [x] summaryStatus 옵셔널체이닝 적용
- [x] summaryStatus props를 선택적으로 수정

## 💡 자세한 설명
- 옵셔널 체이닝을 사용하지 않아 talkPick.summaryStatus에 직접 접근할 경우, talkPick 객체가 아직 존재하지 않는 시점에 속성에 접근하여 `Cannot read properties of undefined (reading ‘summaryStatus’)` 오류가 발생하였습니다.
- 이 문제를 해결하기 위해 props로 받아오는 talkPick.summaryStatus에 옵셔널 체이닝을 적용하고, props 또한 선택적 타입으로 변경하였습니다.
- 값이 없을 경우 summaryStatus를 톡픽 생성 시 기본값인 `PENDING`으로 설정하였습니다.

**오류 수정 후 화면**
<img width="500px" src="https://github.com/user-attachments/assets/c6d85920-a2d6-43b1-bced-dc2a248147c5">


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #282 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **기능 개선**
	- `SummaryBox` 컴포넌트의 `summaryStatus` 속성을 선택적 매개변수로 변경
	- 기본값을 `'PENDING'`으로 설정하여 상태 처리의 유연성 향상

- **버그 수정**
	- `TalkPickSection`에서 선택적 체이닝(`?.`)을 사용하여 잠재적인 런타임 오류 방지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->