### PR TITLE
fix: bestGames 값이 존재할 경우 latestGames로 contents가 갱신되지 않는 문제

### DIFF
--- a/src/pages/LandingPage/LandingPage.tsx
+++ b/src/pages/LandingPage/LandingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import TopBanner from '@/components/molecules/TopBanner/TopBanner';
 import SearchTagBar from '@/components/molecules/SearchTagBar/SearchTagBar';
 import CategoryBox from '@/components/molecules/CategoryBox/CategoryBox';
@@ -38,7 +38,15 @@ const LandingPage = () => {
   const { bestGames } = useBestGameList(activeTab, isBestGamesEnabled);
   const { latestGames } = useLatestGameList(activeTab, isLatestGamesEnabled);
 
-  const contents = bestGames || latestGames || [];
+  const contents = useMemo(() => {
+    if (isBestGamesEnabled) {
+      return bestGames ?? [];
+    }
+    if (isLatestGamesEnabled) {
+      return latestGames ?? [];
+    }
+    return [];
+  }, [isBestGamesEnabled, isLatestGamesEnabled, bestGames, latestGames]);
 
   const handleService = () => {
     setIsServicePreparing(true);


### PR DESCRIPTION
## 💡 작업 내용

- [x] contents 값을 논리 연산이 아닌 조건을 통해 반환되도록 로직 수정

## 💡 자세한 설명

- contents 값이 될 수 있는 bestGames과 latestGames 값을 제어할 수 있는 조건이 따로 존재하지 않기 때문에 특정 상황에서 bestGames 값이 존재하면 latestGames로 변경되지 않는 문제가 발생했습니다.
- 이 문제를 해결하기 위해 useMemo 내부에 존재하는 조건문에 `isBestGamesEnabled`와 `isLatestGamesEnabled`를 기반으로 적합한 값이 반환되도록 로직을 수정하였습니다.
- 값이 undefined일 경우를 대비해 `빈 배열을 기본값`으로 사용하도록 하였습니다.

**오류 수정 후 화면**
![ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/d837749a-6791-47f6-aa05-25dd6499b6fe)


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #285 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **성능 개선**
	- 랜딩 페이지의 게임 콘텐츠 렌더링 최적화
	- `useMemo` 훅을 사용하여 불필요한 재계산 방지
	- 최상의 게임 및 최신 게임 콘텐츠의 효율적인 메모이제이션 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->