### PR TITLE
refactor: 메인 페이지 카테고리 버튼 2개로 수정

### DIFF
--- a/src/components/atoms/CategoryButton/CategoryButton.style.ts
+++ b/src/components/atoms/CategoryButton/CategoryButton.style.ts
@@ -35,4 +35,7 @@ export const labelStyle = css({
   '@media (max-width: 430px)': {
     ...typo.Mobile.Text.Medium_8,
   },
+  '@media (max-width: 320px)': {
+    ...typo.Mobile.Text.Medium_7,
+  },
 });

--- a/src/components/molecules/CategoryBox/CategoryBox.style.ts
+++ b/src/components/molecules/CategoryBox/CategoryBox.style.ts
@@ -4,9 +4,30 @@ export const categoryBoxStyling = css({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  gap: '20px',
+  gap: '21px',
   width: '100%',
+
+  '& button': {
+    flex: 1,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '562px',
+  },
+
   '@media (max-width: 430px)': {
-    gap: '7px',
+    gap: '6.6px',
+    '& button': {
+      flex: 'unset',
+      width: '164px',
+      height: '70px',
+    },
+  },
+
+  '@media (max-width: 320px)': {
+    gap: '6.6px',
+    '& button': {
+      width: '136.5px',
+    },
   },
 });

--- a/src/components/molecules/CategoryBox/CategoryBox.tsx
+++ b/src/components/molecules/CategoryBox/CategoryBox.tsx
@@ -8,36 +8,22 @@ interface CategoryBoxProps {
   handleService: () => void;
 }
 
-const CategoryBox = ({ handleService, isMobile = false }: CategoryBoxProps) => {
-  return isMobile ? (
-    <div css={categoryBoxStyling}>
-      <Link to="/talkpickplace">
-        <CategoryButton isMobile imageType="PickVote" label="톡&픽 플레이스" />
-      </Link>
+const CategoryBox = ({ handleService, isMobile = false }: CategoryBoxProps) => (
+  <div css={categoryBoxStyling}>
+    <Link to="/talkpickplace">
       <CategoryButton
-        isMobile
-        imageType="RandomGame"
-        label="랜덤 밸런스 게임"
-        onClick={handleService}
+        isMobile={isMobile}
+        imageType="PickVote"
+        label="톡&픽 플레이스"
       />
-    </div>
-  ) : (
-    <div css={categoryBoxStyling}>
-      <Link to="/talkpickplace">
-        <CategoryButton imageType="PickVote" label="톡&픽 플레이스" />
-      </Link>
-      <CategoryButton
-        imageType="TodayPick"
-        label="오늘의 톡픽 모음.zip"
-        onClick={handleService}
-      />
-      <CategoryButton
-        imageType="RandomGame"
-        label="랜덤 밸런스 게임"
-        onClick={handleService}
-      />
-    </div>
-  );
-};
+    </Link>
+    <CategoryButton
+      isMobile={isMobile}
+      imageType="RandomGame"
+      label="랜덤 밸런스 게임"
+      onClick={handleService}
+    />
+  </div>
+);
 
 export default CategoryBox;

--- a/src/styles/typo.ts
+++ b/src/styles/typo.ts
@@ -249,6 +249,13 @@ const typo = {
         lineHeight: '1.3',
         letterSpacing: `${8 * -0.05}px`,
       },
+      Medium_7: {
+        fontFamily: 'Pretendard',
+        fontSize: '7.5px',
+        fontWeight: 500,
+        lineHeight: '1.3',
+        letterSpacing: `${8 * -0.05}px`,
+      },
     },
   },
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] `web` 메인페이지 카테고리 버튼 2개로 수정
- [x] `mobile` 메인페이지 화면 너비에 따른 카테고리 버튼 사이즈 비율 다른 이슈 수정
- [x] `mobile` 모바일 320px 일 때, CategoryButton 텍스트 크기 수정

## 💡 자세한 설명
- 웹에서도 모바일 메인페이지와 같이 `CategoryButton`을 두 개로 수정하였습니다. 
- 화면 너비에 따라 `CategoryButton`의 비율이 다른 이슈를 해결하기 위해서 해당 버튼에 대한 스타일을 수정하였고, 미디어 쿼리를 통해 320px일 때의 세부 스타일도 수정하였습니다.
- `CategoryBox`에 웹과 모바일의 JSX 값을 분리할 필요가 없어졌기 때문에 중복되는 코드는 모두 제거하였습니다. 

**모바일 화면**
<img width="300px" src="https://github.com/user-attachments/assets/3e0ae974-6d10-49a9-a2e5-12e0918b8577">

**웹 화면**
<img width="300px" src="https://github.com/user-attachments/assets/54df2334-4d9a-4d60-b898-e9b69338927b">


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #296 
