### PR TITLE
fix: 페이지네이션 적용된 페이지에서 뒤로가기 로직 오류 수정

### DIFF
--- a/src/hooks/search/usePagination.ts
+++ b/src/hooks/search/usePagination.ts
@@ -9,10 +9,13 @@ const usePagination = (defaultPage = 1) => {
   const [page, setPage] = useState(initialPage);
 
   useEffect(() => {
-    setSearchParams((prevParams) => ({
-      ...Object.fromEntries(prevParams.entries()),
-      page: page.toString(),
-    }));
+    setSearchParams(
+      (prevParams) => ({
+        ...Object.fromEntries(prevParams.entries()),
+        page: page.toString(),
+      }),
+      { replace: true },
+    );
   }, [page, setSearchParams]);
 
   const handlePageChange = (newPage: number) => {


### PR DESCRIPTION
## 💡 작업 내용

- [x] usePagination 훅의 URL 동기화 문제 해결 

## 💡 자세한 설명
- `?page=1`과 같은 페이지 관련 파라미터가 URL에 포함될 경우, 뒤로가기 버튼을 눌렀을 때 이전 페이지로 이동되지 않는 오류가 발생하는데, 이는 React Router와 브라우저 히스토리 간의 동기화 문제에서 비롯되고 있습니다.
- 위와 같은 동기화 문제를 해결하기 위해 `replace:true` 옵션을 setSearchParams에 적용 하여 **쿼리 파라미터를 동적 업데이트**하였습니다.

<img width="700px" src="https://github.com/user-attachments/assets/b7c89616-7cf8-4f5c-ab57-a23bc3567f81">


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #297 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- 페이징 전환 시 브라우저 내비게이션 히스토리 업데이트 방식이 개선되어, 페이지 이동 경험이 한층 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->