### PR TITLE
fix: 랜딩페이지 렌더링 이슈 해결

### DIFF
--- a/src/pages/LandingPage/LandingPage.tsx
+++ b/src/pages/LandingPage/LandingPage.tsx
@@ -63,10 +63,9 @@ const LandingPage = () => {
   }, [isBestGamesEnabled, isLatestGamesEnabled, bestGames, latestGames]);
 
   const processedContents = useMemo(() => {
-    if (!member?.id) return [];
     return contents.map((item: GameContent) => ({
       ...item,
-      showBookmark: item.writerId !== member.id,
+      showBookmark: member?.id ? item.writerId !== member.id : false,
     }));
   }, [contents, member?.id]);
 

--- a/src/pages/LandingPage/LandingPage.tsx
+++ b/src/pages/LandingPage/LandingPage.tsx
@@ -22,12 +22,13 @@ import { ToggleGroupValue } from '@/types/toggle';
 import { NOTICE, SUCCESS } from '@/constants/message';
 import { useTodayBalanceGameList } from '@/hooks/game/useTodayBalanceGameList';
 import { todayTalkPickDummyData } from '@/mocks/data/banner';
+import { PATH } from '@/constants/path';
 import * as S from './LandingPage.style';
 
 const LandingPage = () => {
   const isMobile = useIsMobile();
   const navigate = useNavigate();
-  const { isOpen: isLoginModalOpen, openModal, closeModal } = useModal();
+  const { isOpen: isLoginModalOpen, closeModal } = useModal();
   const { isVisible, modalText, showToastModal } = useToastModal();
 
   const { member } = useMemberQuery();
@@ -65,7 +66,7 @@ const LandingPage = () => {
   const processedContents = useMemo(() => {
     return contents.map((item: GameContent) => ({
       ...item,
-      showBookmark: member?.id ? item.writerId !== member.id : false,
+      showBookmark: member?.id ? item.writerId !== member.id : true,
     }));
   }, [contents, member?.id]);
 
@@ -94,7 +95,7 @@ const LandingPage = () => {
       if (!content.id) return;
 
       if (!isLoggedIn()) {
-        openModal();
+        navigate(`/${PATH.LOGIN}`);
         return;
       }
 
@@ -112,7 +113,7 @@ const LandingPage = () => {
         });
       }
     },
-    [createBookmark, deleteBookmark, openModal, showToastModal],
+    [createBookmark, deleteBookmark, navigate, showToastModal],
   );
 
   return (


### PR DESCRIPTION
## 💡 작업 내용

- [x] 랜딩 페이지에서 비로그인 시  **주제별 벨런스 게임** 이 렌더링 되지 않는 이슈 해결

## 💡 자세한 설명

### ✅ 문제 원인
- `useBestGameList` 또는 `useLatestGameList` 으로 받아온 데이터는 contents 라는 이름으로 메모이제이션 합니다.
이 때, 컴포넌트 에서 북마크 아이콘을 출력/미출력 을 위해 `processedContents` 라는 이름으로 2차 가공을 진행하는데, 

(기존)
```typescript
const processedContents = useMemo(() => {
  if (!member?.id) return [];
  return contents.map((item: GameContent) => ({
    ...item,
    showBookmark: item.writerId !== member.id,
  }));
}, [contents, member?.id]);
```
와 같이 member의 id가 없으면 빈 배열을 반환하도록 되어 있었습니다.

원래 의도한 흐름(비로그인 시에는 북마크 아이콘이 랜더링 X, 로그인 시에는 writer.id와의 검증을 통해서)
(수정 후)
```typescript
const processedContents = useMemo(() => {
  return contents.map((item: GameContent) => ({
    ...item,
    showBookmark: member?.id ? item.writerId !== member.id : false,
  }));
}, [contents, member?.id]);
```
로 처리하였습니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #303 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
	- Landing 페이지에서 책갈피 표시 조건을 개선하여, 로그인 여부와 작성자 정보를 기준으로 책갈피가 일관되게 표시되도록 수정했습니다.
	- 로그인하지 않은 사용자가 로그인 페이지로 직접 이동하도록 변경하여 사용자 경험을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->